### PR TITLE
Add exporter and few more configuration keys

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: neuvector
 apiVersion: v1
-version: 1.3.2
+version: 1.3.3
 appVersion: 2.5.0
 description: NeuVector Container Security Platform includes layer 7 container firewall, end-to-end vulnerability scanning, and container process/file monitoring.
 home: https://neuvector.com

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -12,10 +12,7 @@ spec:
   replicas: {{ .Values.controller.replicas }}
   minReadySeconds: 60
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+{{ toYaml .Values.controller.strategy | indent 4 }}
   template:
     metadata:
       labels:
@@ -31,6 +28,8 @@ spec:
           image: "{{ .Values.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.tag }}"
           securityContext:
             privileged: true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
           readinessProbe:
             exec:
               command:

--- a/templates/enforcer-daemonset.yaml
+++ b/templates/enforcer-daemonset.yaml
@@ -31,6 +31,8 @@ spec:
           image: "{{ .Values.registry }}/{{ .Values.enforcer.image.repository }}:{{ .Values.tag }}"
           securityContext:
             privileged: true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
           env:
             - name: CLUSTER_JOIN_ADDR
               value: neuvector-svc-controller.{{ .Release.Namespace }}

--- a/templates/exporter-deployment.yaml
+++ b/templates/exporter-deployment.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.exporter.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: neuvector-prometheus-exporter-pod
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: neuvector-prometheus-exporter-pod
+        release: {{ .Release.Name }}
+      annotations:
+      {{- if .Values.exporter.scrapping }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8068"
+      {{- end }}
+    spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecrets }}
+    {{- end }}
+      containers:
+        - name: neuvector-prometheus-exporter-pod
+          image: "{{ .Values.registry }}/{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
+          imagePullPolicy: Always
+          env:
+            - name: CTRL_API_SERVICE
+              value: neuvector-svc-controller:10443
+            - name: EXPORTER_PORT
+              value: "8068"
+          envFrom:
+            - secretRef:
+                name: neuvector-prometheus-exporter-pod-secret
+      restartPolicy: Always
+{{- end }}

--- a/templates/manager-deployment.yaml
+++ b/templates/manager-deployment.yaml
@@ -32,5 +32,7 @@ spec:
             {{- else }}
               value: "{{ .Values.manager.env.ssl }}"
             {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
       restartPolicy: Always
 {{- end }}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   accessModes:
-    - ReadWriteMany
+{{ toYaml .Values.controller.pvc.accessModes | indent 4 }}
   volumeMode: Filesystem
 {{- if .Values.controller.pvc.storageClass }}
   storageClassName: {{ .Values.controller.pvc.storageClass }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.exporter.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neuvector-prometheus-exporter-pod-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  CTRL_USERNAME: {{ .Values.exporter.CTRL_USERNAME | b64enc | quote }}
+  CTRL_PASSWORD: {{ .Values.exporter.CTRL_PASSWORD | b64enc | quote }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -11,11 +11,18 @@ imagePullSecrets: {}
 controller:
   # If false, controller will not be installed
   enabled: true
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0    
   image:
     repository: neuvector/controller
   replicas: 3
   pvc:
     enabled: false
+    accessModes:
+      - ReadWriteMany
     storageClass:
   azureFileShare:
     enabled: false
@@ -83,9 +90,28 @@ cve:
       tag: latest
     schedule: "0 0 * * *"
 
+exporter:
+  # If false, exporter will not be installed
+  enabled: false
+  scrapping: true
+  image:
+    repository: honestica/neuvector-exporter
+    tag: 3e2f07c1e0b4d5ef225f2cc402ae68f91d45e1c9 
+  # changes this to a readonly user !
+  CTRL_USERNAME: admin
+  CTRL_PASSWORD: admin
+
 docker:
   path: /var/run/docker.sock
-
+  
+resources: {}
+  # limits:
+  #   cpu: 400m
+  #   memory: 2792Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 2280Mi
+    
 containerd:
   enabled: false
   path: /var/run/containerd/containerd.sock

--- a/values.yaml
+++ b/values.yaml
@@ -95,8 +95,8 @@ exporter:
   enabled: false
   scrapping: true
   image:
-    repository: honestica/neuvector-exporter
-    tag: 3e2f07c1e0b4d5ef225f2cc402ae68f91d45e1c9 
+    repository: neuvector/prometheus-exporter
+    tag: 0.9.0
   # changes this to a readonly user !
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin


### PR DESCRIPTION
* Exporter with scrapping annotations so prometheus automatically do it.

* Enable configuration of PVC mode and Deployment strategy so we can deploy it without the needs of `ReadWriteMany` Storage
(cf example https://github.com/honestica/lifen-charts/blob/master/examples/neuvector/values-custom.yaml)

* Enable ressources requests/limits to avoid neuvector heating all the memory.

