### PR TITLE
Fix invalid manifest syntax when controller ingress is enabled.

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -31,7 +31,7 @@ spec:
           servicePort: 8443
 {{- end }}
 ---
-{{- if and .Values.controller.enabled .Values.controller.ingress.enabled -}}
+{{ if and .Values.controller.enabled .Values.controller.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
When helm value `controller.ingress.enabled` is set to `true`, the resulting manifest will include a line like `---apiVersion: extensions/v1beta1`, resulting in an error when applying.