### PR TITLE
Allow TLS hosts and secret name to be specified for Controller

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -46,6 +46,14 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+{{- if .Values.controller.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.controller.ingress.host }}
+{{- if .Values.controller.ingress.secretName }}
+    secretName: {{ .Values.controller.ingress.secretName }}
+{{- end }}
+{{- end }}
   rules:
   - host: {{ .Values.controller.ingress.host }}
     http:

--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,8 @@ controller:
     annotations: 
       ingress.kubernetes.io/protocol: https
       # ingress.kubernetes.io/rewrite-target: /
+    tls: false
+    secretName: {}
   configmap:
     enabled: false
     data: {}


### PR DESCRIPTION
To be consistent with the configurations of Manager ingress, allow TLS hosts and secret name to be specified for Controller ingress as well.