### PR TITLE
Allow updater connection to controller

### DIFF
--- a/templates/controller-service.yaml
+++ b/templates/controller-service.yaml
@@ -24,6 +24,9 @@ spec:
     - port: 18301
       protocol: "UDP"
       name: "cluster-udp-18301"
+    - port: 18400
+      protocol: "TCP"
+      name: "cluster-tcp-18400"
   {{- if .Values.controller.ingress.enabled }}
     - port: 10443
       name: controller


### PR DESCRIPTION
The CVE database updater uses port 18400 to connect to the controller. This PR adds the port to the controller's service, which is currently missing in the chart template.