### PR TITLE
Rework Chart AppVersion and Image tag

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 name: neuvector
 apiVersion: v1
-version: 1.3.3
-appVersion: 2.5.0
+version: 1.3.4
+appVersion: 2.5.3
 description: NeuVector Container Security Platform includes layer 7 container firewall, end-to-end vulnerability scanning, and container process/file monitoring.
 home: https://neuvector.com
 maintainers:

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     {{- end }}
       containers:
         - name: neuvector-controller-pod
-          image: "{{ .Values.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.tag }}"
+          image: "{{ .Values.registry }}/{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.tag }}"
           securityContext:
             privileged: true
           resources:

--- a/templates/enforcer-daemonset.yaml
+++ b/templates/enforcer-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       hostPID: true
       containers:
         - name: neuvector-enforcer-pod
-          image: "{{ .Values.registry }}/{{ .Values.enforcer.image.repository }}:{{ .Values.tag }}"
+          image: "{{ .Values.registry }}/{{ .Values.enforcer.image.repository }}:{{ default .Chart.AppVersion .Values.tag }}"
           securityContext:
             privileged: true
           resources:

--- a/templates/manager-deployment.yaml
+++ b/templates/manager-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     {{- end }}
       containers:
         - name: neuvector-manager-pod
-          image: "{{ .Values.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.tag }}"
+          image: "{{ .Values.registry }}/{{ .Values.manager.image.repository }}:{{ default .Chart.AppVersion .Values.tag }}"
           env:
             - name: CTRL_SERVER_IP
               value: neuvector-svc-controller.{{ .Release.Namespace }}

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,8 @@
 openshift: false
 
 registry: docker.io
-tag: latest
+# Allow tag value for overriding the image tag. Use the AppVersion from Chart.yaml by default.
+# tag:
 imagePullSecrets: {}
 
 controller:


### PR DESCRIPTION
This commit tries to rework how the image tags are managed to simplify
the release process

1) Use of "latest" tag is not recommended.
2) To make changing chart version easier for every subsequent
release as this involves making a change in a single place i.e.
changing AppVersion in Charts.yaml & the value for image tag can be
independent of chart's AppVersion if the tag value is set in
values.yaml.