### PR TITLE
Fix helm warning when overriding values

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 name: neuvector
 apiVersion: v1
-version: 1.3.3
+version: 1.3.4
 appVersion: 2.5.0
 description: NeuVector Container Security Platform includes layer 7 container firewall, end-to-end vulnerability scanning, and container process/file monitoring.
 home: https://neuvector.com

--- a/README.md
+++ b/README.md
@@ -150,17 +150,17 @@ Parameter | Description | Default | Notes
 `openshift` | If deploying in OpenShift, set this to true | `false` | 
 `registry` | image registry | `docker.io` | If Azure, set to my-reg.azurecr.io;<br>if OpenShift, set to docker-registry.default.svc:5000
 `tag` | image tag for controller enforcer manager | `latest` | 
-`imagePullSecrets` | image pull secret | `{}` | 
+`imagePullSecrets` | image pull secret | `nil` | 
 `controller.enabled` | If true, create controller | `true` | 
 `controller.image.repository` | controller image repository | `neuvector/controller` | 
 `controller.replicas` | controller replicas | `3` | 
 `controller.pvc.enabled` | If true, enable persistence for controller using PVC | `false` | Require persistent volume type RWX, and storage 1Gi
 `controller.pvc.storageClass` | Storage Class to be used | `default` | 
 `controller.azureFileShare.enabled` | If true, enable the usage of an existing or statically provisioned Azure File Share | `false` | 
-`controller.azureFileShare.secretName` | The name of the secret containing the Azure file share storage account name and key | `{}` | 
-`controller.azureFileShare.shareName` | The name of the Azure file share to use | `{}` | 
+`controller.azureFileShare.secretName` | The name of the secret containing the Azure file share storage account name and key | `nil` | 
+`controller.azureFileShare.shareName` | The name of the Azure file share to use | `nil` | 
 `controller.ingress.enabled` | If true, create ingress for rest api, must also set ingress host value | `false` | enable this if ingress controller is installed
-`controller.ingress.host` | Must set this host value if ingress is enabled | `{}` | 
+`controller.ingress.host` | Must set this host value if ingress is enabled | `nil` | 
 `controller.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations. 
 `controller.ingress.annotations` | Add annotations to ingress to influence behavior | `ingress.kubernetes.io/protocol: https ingress.kubernetes.io/rewrite-target: /` | see examples in [values.yaml](values.yaml)
 `controller.configmap.enabled` | If true, configure NeuVector using a ConfigMap | `false`
@@ -173,11 +173,11 @@ Parameter | Description | Default | Notes
 `manager.env.ssl` | enable/disable HTTPS and disable/enable HTTP access  | `on`;<br>if ingress is enabled, then default is `off` | 
 `manager.svc.type` | set manager service type for native Kubernetes | `NodePort`;<br>if it is OpenShift platform or ingress is enabled, then default is `ClusterIP` | set to LoadBalancer if using cloud providers, such as Azure, Amazon, Google
 `manager.ingress.enabled` | If true, create ingress, must also set ingress host value | `false` | enable this if ingress controller is installed
-`manager.ingress.host` | Must set this host value if ingress is enabled | `{}` | 
+`manager.ingress.host` | Must set this host value if ingress is enabled | `nil` | 
 `manager.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations. Currently only supports `/` 
 `manager.ingress.annotations` | Add annotations to ingress to influence behavior | `{}` | see examples in [values.yaml](values.yaml)
 `manager.ingress.tls` | If true, TLS is enabled for ingress |`false` | If set, the tls-host used is the one set with `manager.ingress.host`. It might be necessary to set `manager.env.ssl="off"` 
-`manager.ingress.secretName` | Name of the secret to be used for TLS-encryption | `{}` | Secret must be created separately (Let's encrypt, manually)
+`manager.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `cve.updater.enabled` | If true, create cve updater | `false` | 
 `cve.updater.image.repository` | cve updater image repository | `neuvector/updater` | 
 `cve.updater.image.tag` | image tag for cve updater | `latest` | 

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ openshift: false
 
 registry: docker.io
 tag: latest
-imagePullSecrets: {}
+imagePullSecrets:
 
 controller:
   # If false, controller will not be installed
@@ -28,17 +28,17 @@ controller:
     storageClass:
   azureFileShare:
     enabled: false
-    secretName: {}
-    shareName: {}
+    secretName:
+    shareName:
   ingress:
     enabled: false
-    host: {} # MUST be set, if ingress is enabled
+    host: # MUST be set, if ingress is enabled
     path: "/" # or this could be "/api", but might need "rewrite-target" annotation
     annotations: 
       ingress.kubernetes.io/protocol: https
       # ingress.kubernetes.io/rewrite-target: /
     tls: false
-    secretName: {}
+    secretName:
   configmap:
     enabled: false
     data: {}
@@ -75,7 +75,7 @@ manager:
     type: NodePort
   ingress:
     enabled: false
-    host: {} # MUST be set, if ingress is enabled
+    host: # MUST be set, if ingress is enabled
     path: "/"
     annotations: {}
       # kubernetes.io/ingress.class: my-nginx
@@ -83,7 +83,7 @@ manager:
       # nginx.ingress.kubernetes.io/rewrite-target: /
       # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
     tls: false
-    secretName: {} # my-tls-secret
+    secretName: # my-tls-secret
 
 cve:
   updater:


### PR DESCRIPTION
This sets any string values to be unset rather than a `table`

Before this change, every time we ran this chart we got this:
```
Warning: Merging destination map for chart 'neuvector'. Cannot overwrite table item 'host', with non table value: map[]
Warning: Merging destination map for chart 'neuvector'. Cannot overwrite table item 'host', with non table value: map[]
Warning: Merging destination map for chart 'neuvector'. Cannot overwrite table item 'host', with non table value: map[]
Warning: Merging destination map for chart 'neuvector'. Cannot overwrite table item 'host', with non table value: map[]
```

You can test with:
```
helm template .

helm template --set manager.ingress.enabled=true --set manager.ingress.host=blah.example.com

helm template --set manager.ingress.enabled=true --set manager.ingress.host=blah.example.com --set controller.ingress.enabled=true --set controller.ingress.host=blah-controller.example.com  .
```