### PR TITLE
Adding resources settings for each component and cephfs volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Parameter | Description | Default | Notes
 `controller.azureFileShare.enabled` | If true, enable the usage of an existing or statically provisioned Azure File Share | `false` | 
 `controller.azureFileShare.secretName` | The name of the secret containing the Azure file share storage account name and key | `nil` | 
 `controller.azureFileShare.shareName` | The name of the Azure file share to use | `nil` | 
+`controller.cephFsShare.enabled` | If true, enable the usage of an existing or statically provisioned cephFsShare | `false` | 
+`controller.cephFsShare.monitors` | list of the ceph monitoring nodes | `[]` | 
+`controller.cephFsShare.path` | need to be set to the cephFs path, where data should be stored | `nil` | 
+`controller.cephFsShare.user` | user with the permissions to access the cephfs path | `nil` | 
+`controller.cephFsShare.secretName` | name of an existing secret with stored ceph credentials | `nil` | 
 `controller.apisvc.type` | Controller REST API service type | `nil` | 
 `controller.federation.mastersvc.type` | Multi-cluster master cluster service type | `nil` | 
 `controller.federation.managedsvc.type` | Multi-cluster managed cluster service type | `nil` | 

--- a/templates/controller-deployment.yaml
+++ b/templates/controller-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           securityContext:
             privileged: true
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.controller.resources | indent 12 }}
           readinessProbe:
             exec:
               command:
@@ -67,7 +67,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          {{- if or .Values.controller.pvc.enabled .Values.controller.azureFileShare.enabled }}
+          {{- if or .Values.controller.pvc.enabled .Values.controller.azureFileShare.enabled .Values.controller.cephFsShare.enabled }}
             - name: CTRL_PERSIST_CONFIG
               value: "1"
           {{- end }}
@@ -105,6 +105,16 @@ spec:
             secretName: {{ .Values.controller.azureFileShare.secretName }}
             shareName: {{ .Values.controller.azureFileShare.shareName }}
             readOnly: false
+        {{- else if .Values.controller.cephFsShare.enabled }}
+          cephfs:
+            monitors:
+              {{- range .Values.controller.cephFsShare.monitors }}
+              - {{ . }}
+              {{- end }}
+            path: {{ .Values.controller.cephFsShare.path }}
+            user: {{ .Values.controller.cephFsShare.user }}
+            secretRef:
+              name: {{ .Values.controller.cephFsShare.secretName }}
         {{- else }}
           hostPath:
             path: /var/neuvector

--- a/templates/enforcer-daemonset.yaml
+++ b/templates/enforcer-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext:
             privileged: true
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.enforcer.resources | indent 12 }}
           env:
             - name: CLUSTER_JOIN_ADDR
               value: neuvector-svc-controller.{{ .Release.Namespace }}

--- a/templates/exporter-deployment.yaml
+++ b/templates/exporter-deployment.yaml
@@ -45,5 +45,6 @@ spec:
           envFrom:
             - secretRef:
                 name: neuvector-prometheus-exporter-pod-secret
+{{ toYaml .Values.manager.resources | indent 10 }}
       restartPolicy: Always
 {{- end }}

--- a/templates/manager-deployment.yaml
+++ b/templates/manager-deployment.yaml
@@ -38,6 +38,6 @@ spec:
               value: "off"
             {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.manager.resources | indent 12 }}
       restartPolicy: Always
 {{- end }}

--- a/templates/updater-cronjob.yaml
+++ b/templates/updater-cronjob.yaml
@@ -32,5 +32,6 @@ spec:
               env:
                 - name: CLUSTER_JOIN_ADDR
                   value: neuvector-svc-controller.{{ .Release.Namespace }}
+{{ toYaml .Values.manager.resources | indent 10 }}
           restartPolicy: Never
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,16 @@ controller:
     enabled: false
     secretName:
     shareName:
+  cephFsShare:
+    enabled: false
+    monitors:
+      - 127.0.0.1:6789
+      - 127.0.0.2:6789
+      - 127.0.0.3:6789
+    path: /neuvector
+    user: ""
+    #Secret has to be created before
+    secretName: ""
   federation:
     mastersvc:
       type:
@@ -59,6 +69,13 @@ controller:
       # ...
       # userinitcfg.yaml: |
       # ...
+  resources: {}
+  # limits:
+  #   cpu: 400m
+  #   memory: 2792Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 2280Mi
 
 enforcer:
   # If false, enforcer will not be installed
@@ -68,6 +85,13 @@ enforcer:
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master
+  resources: {}
+  # limits:
+  #   cpu: 400m
+  #   memory: 2792Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 2280Mi
 
 manager:
   # If false, manager will not be installed
@@ -98,6 +122,13 @@ cve:
       repository: neuvector/updater
       tag: latest
     schedule: "0 0 * * *"
+  resources: {}
+  # limits:
+  #   cpu: 400m
+  #   memory: 2792Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 2280Mi
 
 exporter:
   # If false, exporter will not be installed
@@ -109,17 +140,17 @@ exporter:
   # changes this to a readonly user !
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin
-
-docker:
-  path: /var/run/docker.sock
-
-resources: {}
+  resources: {}
   # limits:
   #   cpu: 400m
   #   memory: 2792Mi
   # requests:
   #   cpu: 100m
   #   memory: 2280Mi
+
+
+docker:
+  path: /var/run/docker.sock
 
 containerd:
   enabled: false


### PR DESCRIPTION
1. in the existing Helm Chart it is only possible to set resource limits and requests across all components In practice the components scale differently. Therefore the extension that each component has its own resource definitions.

2. possibility to use cephfs as storage for neuvector-controller