### PR TITLE
avoid removing whitespace at the end of line

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -40,7 +40,7 @@ metadata:
 {{- with .Values.controller.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
-{{- end -}}
+{{- end }}
   labels:
     chart: {{ template "neuvector.chart" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
As in the ingress resource for the manager the annotations should be added with a return character at the end of the line, otherwise `labels:` is appended to the last annotation added via the values.yaml file.
```yaml
manager:
  enabled: true
  env:
    ssl: true
  ingress:
    enabled: true
    host: something.example.com
    path: "/"
    annotations:
      ingress.kubernetes.io/protocol: https
      certmanager.k8s.io/cluster-issuer: letsencrypt-prod
    tls: true
    secretName: neuvector-manager-tls
```
produced:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: neuvector-restapi-ingress
  namespace: neuvector
  annotations:
    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
    ingress.kubernetes.io/protocol: httpslabels:
    chart: neuvector-1.5.1
    release: RELEASE-NAME
    heritage: Helm
spec:
  tls:
  - hosts:
    - something.example.com
    secretName: neuvector-controller-tls
  rules:
  - host: something.example.com
    http:
      paths:
      - path: /
        backend:
          serviceName: neuvector-svc-controller-api
          servicePort: 10443
```

where as you can see `httpslabels:` should be:
```yaml
    ingress.kubernetes.io/protocol: https
  labels:
```