### PR TITLE
added option for priorityclasses

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,6 +1,6 @@
 name: core
 apiVersion: v1
-version: 1.6.2
+version: 1.6.3
 appVersion: 4.0.0
 description: Helm chart for NeuVector's core services
 home: https://neuvector.com

--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,6 +1,6 @@
 name: core
 apiVersion: v1
-version: 1.6.1
+version: 1.6.2
 appVersion: 4.0.0
 description: Helm chart for NeuVector's core services
 home: https://neuvector.com

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -60,6 +60,7 @@ Parameter | Description | Default | Notes
 `controller.image.repository` | controller image repository | `neuvector/controller` |
 `controller.replicas` | controller replicas | `3` |
 `controller.disruptionbudget` | controller PodDisruptionBudget. 0 to disable. Recommended value: 2. | `0` |
+`controller.priorityClassName` | controller priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
 `controller.pvc.enabled` | If true, enable persistence for controller using PVC | `false` | Require persistent volume type RWX, and storage 1Gi
 `controller.pvc.storageClass` | Storage Class to be used | `default` |
 `controller.azureFileShare.enabled` | If true, enable the usage of an existing or statically provisioned Azure File Share | `false` |
@@ -76,9 +77,11 @@ Parameter | Description | Default | Notes
 `controller.configmap.data` | NeuVector configuration in YAML format | `{}`
 `enforcer.enabled` | If true, create enforcer | `true` |
 `enforcer.image.repository` | enforcer image repository | `neuvector/enforcer` |
+`enforcer.priorityClassName` | enforcer priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
 `enforcer.tolerations` | List of node taints to tolerate | `- effect: NoSchedule`<br>`key: node-role.kubernetes.io/master` | other taints can be added after the default
 `manager.enabled` | If true, create manager | `true` |
 `manager.image.repository` | manager image repository | `neuvector/manager` |
+`manager.priorityClassName` | manager priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
 `manager.env.ssl` | If false, manager will listen on HTTP access instead of HTTPS | `true` |
 `manager.svc.type` | set manager service type for native Kubernetes | `NodePort`;<br>if it is OpenShift platform or ingress is enabled, then default is `ClusterIP` | set to LoadBalancer if using cloud providers, such as Azure, Amazon, Google
 `manager.ingress.enabled` | If true, create ingress, must also set ingress host value | `false` | enable this if ingress controller is installed
@@ -90,9 +93,11 @@ Parameter | Description | Default | Notes
 `cve.updater.enabled` | If true, create cve updater | `true` |
 `cve.updater.image.repository` | cve updater image repository | `neuvector/updater` |
 `cve.updater.image.tag` | image tag for cve updater | `latest` |
+`cve.updater.priorityClassName` | cve updater priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
 `cve.updater.schedule` | cronjob cve updater schedule | `0 0 * * *` |
 `cve.scanner.enabled` | If true, external scanners will be deployed | `true` |
 `cve.scanner.image.repository` | external scanner image repository | `neuvector/scanner` |
+`cve.scanner.priorityClassName` | cve scanner priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
 `cve.scanner.replicas` | external scanner replicas | `3` |
 `cve.scanner.dockerPath` | the remote docker socket if CI/CD integration need scan images before they are pushed to the registry | `nil` |
 `docker.path` | docker path | `/var/run/docker.sock` |

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -42,6 +42,9 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets }}
     {{- end }}
+    {{- if .Values.controller.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+    {{- end }}
       containers:
         - name: neuvector-controller-pod
           image: "{{ .Values.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.tag }}"

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -33,6 +33,9 @@ spec:
 {{ toYaml .Values.enforcer.tolerations | indent 8 }}
     {{- end }}
       hostPID: true
+    {{- if .Values.enforcer.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+    {{- end }}
       containers:
         - name: neuvector-enforcer-pod
           image: "{{ .Values.registry }}/{{ .Values.enforcer.image.repository }}:{{ .Values.tag }}"

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -27,6 +27,9 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets }}
     {{- end }}
+    {{- if .Values.manager.priorityClassName }}
+      priorityClassName: {{ .Values.controller.priorityClassName }}
+    {{- end }}
       containers:
         - name: neuvector-manager-pod
           image: "{{ .Values.registry }}/{{ .Values.manager.image.repository }}:{{ .Values.tag }}"

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -28,6 +28,9 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets }}
     {{- end }}
+    {{- if .Values.cve.scanner.priorityClassName }}
+      priorityClassName: {{ .Values.cve.scanner.priorityClassName }}
+    {{- end }}
       containers:
         - name: neuvector-scanner-pod
           image: "{{ .Values.registry }}/{{ .Values.cve.scanner.image.repository }}:latest"

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           imagePullSecrets:
             - name: {{ .Values.imagePullSecrets }}
         {{- end }}
-        {{- if .Values.controller.priorityClassName }}
+        {{- if .Values.cve.updater.priorityClassName }}
           priorityClassName: {{ .Values.cve.updater.priorityClassName }}
         {{- end }}
           containers:

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -26,6 +26,9 @@ spec:
           imagePullSecrets:
             - name: {{ .Values.imagePullSecrets }}
         {{- end }}
+        {{- if .Values.controller.priorityClassName }}
+          priorityClassName: {{ .Values.cve.updater.priorityClassName }}
+        {{- end }}
           containers:
             - name: neuvector-updater-pod
               image: "{{ .Values.registry }}/{{ .Values.cve.updater.image.repository }}:{{ .Values.cve.updater.image.tag }}"

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -21,6 +21,7 @@ controller:
     repository: neuvector/controller
   replicas: 3
   disruptionbudget: 0
+  priorityClassName:
   apisvc:
     type:
   pvc:
@@ -67,6 +68,7 @@ enforcer:
   enabled: true
   image:
     repository: neuvector/enforcer
+  priorityClassName:
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master
@@ -76,6 +78,7 @@ manager:
   enabled: true
   image:
     repository: neuvector/manager
+  priorityClassName:
   env:
     ssl: true
   svc:
@@ -100,6 +103,7 @@ cve:
       repository: neuvector/updater
       tag: latest
     schedule: "0 0 * * *"
+    priorityClassName:
   scanner:
     enabled: true
     replicas: 3
@@ -111,6 +115,7 @@ cve:
         maxUnavailable: 0
     image:
       repository: neuvector/scanner
+    priorityClassName:
 
 docker:
   path: /var/run/docker.sock


### PR DESCRIPTION
In environments with capacity/resource pressure, which may also only be the case during cluster update procedures, it is necessary to ensure that some of the neuvector components get scheduling priority to other resources in the cluster to ensure neuvector's security features are still enforced.

This PR adds the option to add separate priorityclasses-references for each component