### PR TITLE
Upgrade ingress templates to Kubernetes >= 1.19

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,6 +1,6 @@
 name: core
 apiVersion: v1
-version: 1.6.9
+version: 1.7.0
 appVersion: 4.0.0
 description: Helm chart for NeuVector's core services
 home: https://neuvector.com

--- a/charts/core/templates/controller-ingress.yaml
+++ b/charts/core/templates/controller-ingress.yaml
@@ -14,12 +14,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-{{- if .Values.manager.ingress.tls }}
+{{- if .Values.controller.ingress.tls }}
   tls:
   - hosts:
-    - {{ .Values.manager.ingress.host }}
-{{- if .Values.manager.ingress.secretName }}
-    secretName: {{ .Values.manager.ingress.secretName }}
+    - {{ .Values.controller.ingress.host }}
+{{- if .Values.controller.ingress.secretName }}
+    secretName: {{ .Values.controller.ingress.secretName }}
 {{- end }}
 {{- end }}
   rules:

--- a/charts/core/templates/controller-ingress.yaml
+++ b/charts/core/templates/controller-ingress.yaml
@@ -1,14 +1,11 @@
-{{- if and .Values.manager.enabled .Values.manager.ingress.enabled -}}
+{{- if and .Values.controller.enabled .Values.controller.ingress.enabled }}
 {{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
-  name: neuvector-webui-ingress
+  name: neuvector-restapi-ingress
   namespace: {{ .Release.Namespace }}
-{{- with .Values.manager.ingress.annotations }}
+{{- with .Values.controller.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -26,21 +23,18 @@ spec:
 {{- end }}
 {{- end }}
   rules:
-  - host: {{ .Values.manager.ingress.host }}
+  - host: {{ .Values.controller.ingress.host }}
     http:
       paths:
-      - path: {{ .Values.manager.ingress.path }}
+      - path: {{ .Values.controller.ingress.path }}
+        pathType: Prefix
         backend:
-          serviceName: neuvector-service-webui
-          servicePort: 8443
-{{- end }}
-{{- if and .Values.controller.enabled .Values.controller.ingress.enabled }}
----
-{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
-apiVersion: networking.k8s.io/v1
+          service:
+            name: neuvector-svc-controller-api
+            port:
+              number: 10443
 {{- else }}
 apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: neuvector-restapi-ingress
@@ -70,4 +64,5 @@ spec:
         backend:
           serviceName: neuvector-svc-controller-api
           servicePort: 10443
+{{- end }}
 {{- end -}}

--- a/charts/core/templates/manager-ingress.yaml
+++ b/charts/core/templates/manager-ingress.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.manager.enabled .Values.manager.ingress.enabled -}}
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: neuvector-webui-ingress
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.manager.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+{{- if .Values.manager.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.manager.ingress.host }}
+{{- if .Values.manager.ingress.secretName }}
+    secretName: {{ .Values.manager.ingress.secretName }}
+{{- end }}
+{{- end }}
+  rules:
+  - host: {{ .Values.manager.ingress.host }}
+    http:
+      paths:
+      - path: {{ .Values.manager.ingress.path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: neuvector-service-webui
+            port:
+              number: 8443
+{{- else }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: neuvector-webui-ingress
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.manager.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+{{- if .Values.manager.ingress.tls }}
+  tls:
+  - hosts:
+    - {{ .Values.manager.ingress.host }}
+{{- if .Values.manager.ingress.secretName }}
+    secretName: {{ .Values.manager.ingress.secretName }}
+{{- end }}
+{{- end }}
+  rules:
+  - host: {{ .Values.manager.ingress.host }}
+    http:
+      paths:
+      - path: {{ .Values.manager.ingress.path }}
+        backend:
+          serviceName: neuvector-service-webui
+          servicePort: 8443
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
Fixes https://github.com/neuvector/neuvector-helm/issues/74

- Ingress templates have been migrated to Kubernetes >= 1.19
- Backwards compatibility to Kubernetes < 1.19 is ensured
- Ingress templates for controller and manager have been split into separate template files to match the convention
- An ingress template renders either an ingress resource for Kubernetes >= 1.19 or Kubernetes < 1.19
- Because the spec structure differs between networking.k8s.io/v1.Ingress and extensions/v1beta1.Ingress, I propose to have a single if block instead more fine grained if block to loosen DRY principles in favor of clarity