### PR TITLE
allow specifying scanner image tag

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,6 +1,6 @@
 name: core
 apiVersion: v1
-version: 1.7.2
+version: 1.7.3
 appVersion: 4.2.0
 description: Helm chart for NeuVector's core services
 home: https://neuvector.com

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -114,6 +114,7 @@ Parameter | Description | Default | Notes
 `cve.updater.schedule` | cronjob cve updater schedule | `0 0 * * *` |
 `cve.scanner.enabled` | If true, external scanners will be deployed | `true` |
 `cve.scanner.image.repository` | external scanner image repository | `neuvector/scanner` |
+`cve.scanner.image.tag` | external scanner image tag | `latest` |
 `cve.scanner.priorityClassName` | cve scanner priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
 `cve.scanner.replicas` | external scanner replicas | `3` |
 `cve.scanner.dockerPath` | the remote docker socket if CI/CD integration need scan images before they are pushed to the registry | `nil` |

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccount: {{ .Values.serviceAccount }}
       containers:
         - name: neuvector-scanner-pod
-          image: "{{ .Values.registry }}/{{ .Values.cve.scanner.image.repository }}:latest"
+          image: "{{ .Values.registry }}/{{ .Values.cve.scanner.image.repository }}:{{ .Values.cve.scanner.image.tag }}"
           imagePullPolicy: Always
           env:
             - name: CLUSTER_JOIN_ADDR

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -153,6 +153,7 @@ cve:
         maxUnavailable: 0
     image:
       repository: neuvector/scanner
+      tag: latest
     priorityClassName:
     resources: {}
       # limits:


### PR DESCRIPTION
Would like to be able to specify the version of the scanner image to use rather than hard-coding latest (default is still latest if not explicitly changed).