### PR TITLE
add Route for enable services

### DIFF
--- a/charts/core/templates/route.yaml
+++ b/charts/core/templates/route.yaml
@@ -20,4 +20,82 @@ spec:
     targetPort: manager
   tls:
     termination: passthrough
+{{- if .Values.controller.apisvc.type }}
+{{- if or (eq .Values.controller.apisvc.type "ClusterIP") (eq .Values.controller.apisvc.type "NodePort") }}
+---
+{{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: route.openshift.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: Route
+metadata:
+  name: neuvector-route-controller-api
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  to:
+    kind: Service
+    name: neuvector-svc-controller-api
+  port:
+    targetPort: controller-api
+  tls:
+    termination: passthrough
+{{ end -}}
+{{- end }}
+{{- if .Values.controller.federation.mastersvc.type }}
+{{- if or (eq .Values.controller.federation.mastersvc.type "ClusterIP") (eq .Values.controller.federation.mastersvc.type "NodePort") }}
+---
+{{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: route.openshift.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: Route
+metadata:
+  name: neuvector-route-controller-fed-master
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  to:
+    kind: Service
+    name: neuvector-svc-controller-fed-master
+  port:
+    targetPort: fed
+  tls:
+    termination: passthrough
+{{ end -}}
+{{- end }}
+{{- if .Values.controller.federation.managedsvc.type }}
+{{- if or (eq .Values.controller.federation.managedsvc.type "ClusterIP") (eq .Values.controller.federation.managedsvc.type "NodePort") }}
+---
+{{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: route.openshift.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: Route
+metadata:
+  name: neuvector-route-controller-fed-managed
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  to:
+    kind: Service
+    name: neuvector-svc-controller-fed-managed
+  port:
+    targetPort: fed
+  tls:
+    termination: passthrough
+{{ end -}}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
- create neuvector-route-controller-api when .Values.controller.apisvc.type set to ClusterIP or NodePort
- create neuvector-route-controller-fed-master when .Values.controller.federation.mastersvc.type set to ClusterIP or NodePort
- create neuvector-route-controller-fed-managed when .Values.controller.federation.managedsvc.type set to ClusterIP or NodePort