### PR TITLE
v1beta1 for CRDs is deprecated

### DIFF
--- a/charts/crd/templates/crd.yaml
+++ b/charts/crd/templates/crd.yaml
@@ -3,7 +3,7 @@
 {{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: apiextensions.k8s.io/v1
 {{- else }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 {{- end }}
 kind: CustomResourceDefinition
 metadata:
@@ -161,7 +161,7 @@ spec:
 {{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: apiextensions.k8s.io/v1
 {{- else }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 {{- end }}
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition