### PR TITLE
Set 'regsecret' as default for imagePullSecrets

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -7,7 +7,7 @@ openshift: false
 registry: registry.neuvector.com
 tag: 4.4.2
 oem:
-imagePullSecrets:
+imagePullSecrets: regsecret
 psp: false
 serviceAccount: default
 


### PR DESCRIPTION
This is the default name from the repo, so it seems to track that defaults should be consistent.