### PR TITLE
Add serviceaccount. Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ $ helm search repo neuvector/core
 $ kubectl create namespace neuvector
 ```
 
-- Create a new service account **if** you don't want to use the 'default'. Specify the service account name in charts' values.yaml file.
-```console
-$ kubectl create serviceaccount neuvector -n neuvector
-```
-
 - Configure Kubernetes to pull from the NeuVector container registry.
 ```console
 $ kubectl create secret docker-registry regsecret -n neuvector --docker-server=https://index.docker.io/v1/ --docker-username=your-name --docker-password=your-password --docker-email=your-email

--- a/charts/core/templates/serviceaccount.yaml
+++ b/charts/core/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.openshift}}
+{{- if ne .Values.serviceAccount "default"}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Adding back serviceaccount yaml to create service account if service account name is different than default. This avoids need to create service account manually by user. This is one of the Rancher requirement to go into feature chart.