### PR TITLE
feat(monitor): add Service and ServiceMonitor resources

### DIFF
--- a/charts/monitor/Chart.yaml
+++ b/charts/monitor/Chart.yaml
@@ -1,6 +1,6 @@
 name: monitor
 apiVersion: v1
-version: 2.2.0
+version: 2.3.0
 appVersion: 5.0.0
 description: Helm chart for NeuVector monitor services
 home: https://neuvector.com

--- a/charts/monitor/templates/exporter-service.yaml
+++ b/charts/monitor/templates/exporter-service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.exporter.svc.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: neuvector-prometheus-exporter
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.exporter.svc.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app: neuvector-prometheus-exporter
+spec:
+  type: {{ .Values.exporter.svc.type }}
+  {{- if and .Values.exporter.svc.loadBalancerIP (eq .Values.exporter.svc.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.exporter.svc.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - port: 8068
+      name: metrics
+      protocol: TCP
+  selector:
+    app: neuvector-prometheus-exporter-pod
+{{- end }}

--- a/charts/monitor/templates/exporter-servicemonitor.yaml
+++ b/charts/monitor/templates/exporter-servicemonitor.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.exporter.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: neuvector-prometheus-exporter
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.exporter.serviceMonitor.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.exporter.serviceMonitor.labels }}
+    {{- toYaml .Values.exporter.serviceMonitor.labels | nindent 4}}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: neuvector-exporter-exporter
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      {{- if .Values.exporter.serviceMonitor.interval }}
+      interval: {{ .Values.exporter.serviceMonitor.interval }}
+      {{- end }}
+      path: "/metrics"
+      {{- if .Values.exporter.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.exporter.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.exporter.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.exporter.serviceMonitor.relabelings | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -16,3 +16,26 @@ exporter:
   # changes this to a readonly user !
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin
+
+  svc:
+    enabled: false
+    type: NodePort
+    loadBalancerIP:
+    annotations: {}
+      # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      # service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "apps-subnet"
+
+  serviceMonitor:
+    enabled: false
+    # labels for the ServiceMonitor.
+    labels: {}
+    # annotations for the ServiceMonitor.
+    annotations: {}
+    # Scrape interval. If not set, the Prometheus default scrape interval is used.
+    interval: ""
+    # MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
+    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    metricRelabelings: []
+    # RelabelConfigs to apply to samples before scraping
+    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    relabelings: []


### PR DESCRIPTION
Implements optional Service and ServiceMonitor resources that may be used to monitor NeuVector using a kube-prometheus-stack (aka prometheus-operator) style setup.

I'm opening this merge request against the 5.0.0 branch since that is where where latest NeuVector release is on. Please let me know if you want to to rebase/recreate this against a different branch.

* fixes #164 