### PR TITLE
Add option to not provision RBAC objects

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -62,6 +62,7 @@ Parameter | Description | Default | Notes
 `tag` | image tag for controller enforcer manager | `latest` |
 `oem` | OEM release name | `nil` |
 `imagePullSecrets` | image pull secret | `nil` |
+`rbac` | NeuVector RBAC manifests are installed when rbac is enabled | `true` |
 `psp` | NeuVector Pod Security Policy when psp policy is enabled | `false` |
 `serviceAccount` | Service account name for NeuVector components | `default` |
 `controller.enabled` | If true, create controller | `true` |

--- a/charts/core/templates/clusterrole.yaml
+++ b/charts/core/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac -}}
 {{- $oc4 := and .Values.openshift (semverCompare ">=1.12-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) -}}
 {{- $oc3 := and .Values.openshift (not $oc4) (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) -}}
 {{- if $oc3 }}
@@ -116,4 +117,5 @@ rules:
   verbs:
   - get
   - list
+{{- end }}
 {{- end }}

--- a/charts/core/templates/clusterrolebinding.yaml
+++ b/charts/core/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac -}}
 {{- $oc4 := and .Values.openshift (semverCompare ">=1.12-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) -}}
 {{- $oc3 := and .Values.openshift (not $oc4) (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) -}}
 
@@ -142,4 +143,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/core/templates/rolebinding.yaml
+++ b/charts/core/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac -}}
 {{- $oc4 := and .Values.openshift (semverCompare ">=1.12-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) -}}
 {{- $oc3 := and .Values.openshift (not $oc4) (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) -}}
 
@@ -51,4 +52,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -9,6 +9,7 @@ tag: 5.0.0
 oem:
 imagePullSecrets:
 psp: false
+rbac: true
 serviceAccount: default
 
 controller:


### PR DESCRIPTION
As the cluster-wide object names are hard-coded, we need to disable the RBAC manifests in our branches to be able to deploy it, otherwise it errors with this message:

```
ClusterRole "neuvector-binding-app" in namespace "" exists and cannot be imported into the current release
```