### PR TITLE
Change indentation of init-configmap to 2 spaces

### DIFF
--- a/charts/core/templates/init-configmap.yaml
+++ b/charts/core/templates/init-configmap.yaml
@@ -9,5 +9,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.controller.configmap.data | indent 4 }}
+{{ toYaml .Values.controller.configmap.data | indent 2 }}
 {{- end }}


### PR DESCRIPTION
Since the manually typed YAML is indented by 2 spaces, it makes sense to also import the dynamic content with 2 spaces.