### PR TITLE
Update READMEs for repo and charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ core | Deploy NeuVector container security core services. [chart](charts/core)
 crd | Deploy CRD services before installing NeuVector container security platform. [chart](charts/crd)
 monitor | Deploy monitoring services, such as Prometheus exporter. [chart](charts/monitor)
 
-**IMPORTANT** - Each chart has a set of configuration values, especially for the 'core' chart. Review the Helm chart configuration values [here](charts/core) and make any required changes to the values.yaml file for your deployment.
+**IMPORTANT** - Each chart has a set of configuration values, especially for the 'core' chart. Review the Helm chart configuration values [here](charts/core) and make any required changes to the `values.yaml` file for your deployment.
 
 ### Adding chart repo
 
@@ -24,7 +24,7 @@ $ helm search repo neuvector/core
 
 ### Versioning
 
-Helm charts for officially released product are published from the release branch of the repository. The main branch is used for the charts of the product in the development. Typically the charts in the main branch are published with the alpha, beta or rc tag. They can be discovered with --devel option.
+Helm charts for officially released product are published from the release branch of the repository. The main branch is used for the charts of the product in the development. Typically, the charts in the main branch are published with the alpha, beta or rc tag. They can be discovered with --devel option.
 
 ```console
 $ helm search repo neuvector/core -l
@@ -50,23 +50,13 @@ neuvector/core	1.8.9        	4.4.3      	Helm chart for NeuVector's core service
 
 ### Deploy in Kubernetes
 
-- Create the NeuVector namespace.
-```console
-$ kubectl create namespace neuvector
-```
-
-- Configure Kubernetes to pull from the NeuVector container registry.
-```console
-$ kubectl create secret docker-registry regsecret -n neuvector --docker-server=https://index.docker.io/v1/ --docker-username=your-name --docker-password=your-password --docker-email=your-email
-```
-
-Where ’your-name’ is your registry username, ’your-password’ is your registry password, ’your-email’ is your email.
-
-To install the chart with the release name `my-release` and image pull secret:
+To install the chart with the release name `neuvector`:
 
 ```console
-$ helm install my-release --namespace neuvector neuvector/core  --set imagePullSecrets=regsecret
+$ helm install neuvector --namespace neuvector --create-namespace neuvector/core
 ```
+
+You can find a list of all config options in the [README of the core chart](charts/core).
 
 ### Deploy in RedHat OpenShift
 
@@ -91,37 +81,24 @@ $ oc -n neuvector adm policy add-scc-to-user privileged -z default
 $ oc delete rolebinding -nneuvector system:openshift:scc:privileged
 ```
 
-- Configure Openshift to pull from the NeuVector container registry.
-```console
-$ oc create secret docker-registry regsecret -n neuvector --docker-server=https://index.docker.io/v1/ --docker-username=your-name --docker-password=your-password --docker-email=your-email
-```
-
-To install the chart with the release name `my-release`:
+To install the chart with the release name `neuvector`:
 
 ```console
-$ helm install my-release --namespace neuvector neuvector/core --set openshift=true,imagePullSecrets=regsecret,crio.enabled=true
+$ helm install neuvector --namespace neuvector neuvector/core --set openshift=true,crio.enabled=true
 ```
-
-To install the chart with the release name `my-release` and your private registry:
-
-```console
-$ helm install my-release --namespace neuvector neuvector/core --set openshift=true,imagePullSecrets=regsecret,crio.enabled=true,registry=your-private-registry
-```
-
-If you are using a private registry, and want to enable the updater cronjob, please create a script, run it as a cronjob before midnight or the updater daily schedule.
 
 ## Rolling upgrade
 
 ```console
-$ helm upgrade my-release --set imagePullSecrets=regsecret,tag=4.4.0 neuvector/core
+$ helm upgrade neuvector --set tag=5.0.2 neuvector/core
 ```
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `my-release` deployment:
+To uninstall/delete the `neuvector` deployment:
 
 ```console
-$ helm delete my-release
+$ helm delete neuvector
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -131,7 +108,25 @@ The command removes all the Kubernetes components associated with the chart and 
 If you are using a private registry, you need pull NeuVector images of the specified version to your own registry and add registry name when installing the chart.
 
 ```console
-$ helm install my-release --namespace neuvector neuvector/core --set registry=your-private-registry
+$ helm install neuvector --namespace neuvector neuvector/core --set registry=your-private-registry
+```
+
+If your registry needs authentication, create a secret with the authentication information:
+
+```console
+$ kubectl create secret docker-registry regsecret -n neuvector --docker-server=https://your-private-registry/ --docker-username=your-name --docker-password=your-password --docker-email=your-email
+```
+
+or for OpenShift:
+
+```console
+$ oc create secret docker-registry regsecret -n neuvector --docker-server=https://your-private-registry/ --docker-username=your-name --docker-password=your-password --docker-email=your-email
+```
+
+And install the helm chart with at least these values:
+
+```console
+$ helm install neuvector --namespace neuvector neuvector/core --set imagePullSecrets=regsecret,registry=your-private-registry
 ```
 
 To keep the vulnerability database up-to-date, you want to create a script, run it as a cronjob to pull the updater and scanner images periodically to your own registry.

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,55 +1,12 @@
 # NeuVector Helm Chart
 
 Helm chart for NeuVector container security's core services.
- 
-## Preparation if using Helm 2
-
-- Kubernetes 1.7+
-- Helm installed and Tiller pod is running
-- Cluster role `cluster-admin` available, check by:
-
-```console
-$ kubectl get clusterrole cluster-admin
-```
-
-If nothing returned, then add the `cluster-admin`:
-
-cluster-admin.yaml
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cluster-admin
-rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - '*'
-```
-
-```console
-$ kubectl create -f cluster-admin.yaml
-```
-
-- If you have not created a service account for tiller, and give it admin abilities on the cluster:
-
-```console
-$ kubectl create serviceaccount --namespace kube-system tiller
-$ kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-$ kubectl patch deployment tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}' -n kube-system
-```
 
 ## CRD
-Because the CRD (Custom Resource Definition) policies can be deployed before NeuVector's core product, a new 'crd' helm chart is created. The crd template in the 'core' chart is kept for the backward compatibility. Please set 'crdwebhook.enabled' to false, if you use the new 'crd' chart.
+Because the CRD (Custom Resource Definition) policies can be deployed before NeuVector's core product, a new 'crd' helm chart is created. The crd template in the 'core' chart is kept for the backward compatibility. Please set `crdwebhook.enabled` to false, if you use the new 'crd' chart.
 
 ## Choosing container runtime
-The NeuVector platform supports docker, cri-o and containerd as the container runtime. For a k3s/rke2, or bottlerocket cluster, they have their own runtime socket path. You should enable their runtime options, k3s.enabled and bottlerocket.enabled, respectively.
+The NeuVector platform supports docker, cri-o and containerd as the container runtime. For a k3s/rke2, or bottlerocket cluster, they have their own runtime socket path. You should enable their runtime options, `k3s.enabled` and `bottlerocket.enabled`, respectively.
 
 ## Configuration
 
@@ -219,7 +176,3 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```console
 $ helm install my-release --namespace neuvector ./neuvector-helm/ -f values.yaml
 ```
-
----
-Contact <support@neuvector.com> for access to container registry and docs.
-

--- a/charts/crd/README.md
+++ b/charts/crd/README.md
@@ -1,8 +1,8 @@
 # NeuVector Helm Chart
 
-Helm chart for NeuVector container security's CRD services. NeuVector's CRD (Custom Resource Definition) capture and declare application security policies early in the pipeline, then defined policies can be deployed together with the contaier applications.
+Helm chart for NeuVector container security's CRD services. NeuVector's CRD (Custom Resource Definition) capture and declare application security policies early in the pipeline, then defined policies can be deployed together with the container applications.
 
-Because the CRD poclies can be deployed before NeuVector's core product, this separate helm chart is created. For the backward compatibility reason, crd.yaml is not removed in the 'core' chart. If you use this 'crd' chart, please set 'crdwebhook.enabled' to false in the 'core' chart.
+Because the CRD policies can be deployed before NeuVector's core product, this separate helm chart is created. For the backward compatibility reason, crd.yaml is not removed in the 'core' chart. If you use this 'crd' chart, please set `crdwebhook.enabled` to false in the 'core' chart.
  
 ## Configuration
 
@@ -13,7 +13,3 @@ Parameter | Description | Default | Notes
 `openshift` | If deploying in OpenShift, set this to true | `false` |
 `serviceAccount` | Service account name for NeuVector components | `default` |
 `crdwebhook.type` | crd webhook type | `ClusterIP` |
-
----
-Contact <support@neuvector.com> for access to Docker Hub and docs.
-

--- a/charts/monitor/README.md
+++ b/charts/monitor/README.md
@@ -16,7 +16,3 @@ Parameter | Description | Default | Notes
 `exporter.image.tag` | exporter image tag | `latest` |
 `exporter.CTRL_USERNAME` | Username to login to the controller. Suggest to replace the default admin user to a read-only user | `admin` |
 `exporter.CTRL_PASSWORD` | Passowrd to login to the controller. | `admin` |
-
----
-Contact <support@neuvector.com> for access to Docker Hub and docs.
-


### PR DESCRIPTION
* Since NeuVector is now open-source, there is no need for a registry secret anymore. This removes the references to it and adds additional information on how to install NeuVector from a private registry that needs authentication instead.
* References to contact support in order to get access to the NeuVector private registry are removed
* References to Helm 2 are removed. Helm 2 has been EOL for two years now.
* The default release name is changed from `my-release` to `neuvector`. Users tend to copy&paste commands and may be annoyed then that resources are prefixed with `my-release`.
* Some typos are fixed