### PR TITLE
The node-role.kubernetes.io/master taint is deprecated and kubeadm will stop using it in version 1.25

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -212,6 +212,8 @@ enforcer:
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
   resources: {}
     # limits:
     #   cpu: 400m


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#changes-by-kind-4