### PR TITLE
5.0.5

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -2,10 +2,10 @@ name: core
 apiVersion: v1
 version: 2.2.5
 appVersion: 5.0.5
-description: Helm chart for NeuVector's core services
+description: Helm chart for NeuVector's core services on EKS
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4
 maintainers:
-  - name: becitsthere
-    email: support@neuvector.com
+  - name: SUSE Public Cloud Engineering
+    email: public-cloud-users@susecloud.net
 engine: gotpl

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -23,8 +23,8 @@ controller:
       maxUnavailable: 0
   image:
     repository: suse/neuvector/controller
-    tag: 5.0.3
-    hash: sha256:dc88311c8af3a9c3cab2a3ea00a8556bb4e1ac2c7defeb841557f75cb74f86b3
+    tag: 5.0.5
+    hash: sha256:761a1cfcfe3228fe3b4a60b9eef3cf1b33065c427839024a52c8ce1c7acd0af1
   replicas: 3
   disruptionbudget: 0
   schedulerName:
@@ -212,7 +212,7 @@ enforcer:
   image:
     repository: suse/neuvector/enforcer
     tag: 5.0.5
-    hash:
+    hash: sha256:17554ce765d144c417569041a9599f3a7132e6f66e2ac19bb0d45f5919abbc72
   priorityClassName:
   podLabels: {}
   podAnnotations: {}
@@ -234,8 +234,8 @@ manager:
   enabled: true
   image:
     repository: suse/neuvector/manager
-    tag: 5.0.3
-    hash: sha256:eee3b7001135ff3caed6b5125bd0843ae528302f8bf31f584470013d060a5241
+    tag: 5.0.5
+    hash: sha256:6df964f1ea419f8590b865cd95e26db1c08da6e6a432305100e0755f6d1fb912
   priorityClassName:
   env:
     ssl: true
@@ -305,8 +305,10 @@ cve:
     secure: false
     image:
       repository: suse/neuvector/updater
-      tag: 5
-      hash: sha256:802c37b0b756bd254dc9605436d5bd66009de4b4bfdb631762c356a3f608674c
+      # updater does not have minor/patch version tagging,
+      # but ECR requires it, so we have to make one up (using date)
+      tag: 5.0.20221129
+      hash: sha256:ef98e30e0811dfcdb47e86807f4a8e2bb7dfc7975109cca85b1b4cc9412ab226
     schedule: "0 0 * * *"
     priorityClassName:
     podLabels: {}
@@ -326,8 +328,10 @@ cve:
         maxUnavailable: 0
     image:
       repository: suse/neuvector/scanner
-      tag: 5
-      hash: sha256:b8850536d05a17b18ba3832b0c8b8390d4ab4580c974173b03937cc9d963fd00
+      # scanner does not have minor/patch version tagging,
+      # but ECR requires it, so we have to make one up (using date)
+      tag: 5.0.20221129
+      hash: sha256:54dd64bff2679baa6a1644c392ea7eaaa9f1c1e9111ab8b04c66d8454d648cff
     priorityClassName:
     resources: {}
       # limits:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -4,7 +4,7 @@
 
 openshift: false
 
-registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse
+registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com
 tag: 5.0.5
 oem:
 imagePullSecrets:
@@ -22,8 +22,9 @@ controller:
       maxSurge: 1
       maxUnavailable: 0
   image:
-    repository: neuvector/controller
-    hash:
+    repository: suse/neuvector/controller
+    tag: 5.0.3
+    hash: sha256:dc88311c8af3a9c3cab2a3ea00a8556bb4e1ac2c7defeb841557f75cb74f86b3
   replicas: 3
   disruptionbudget: 0
   schedulerName:
@@ -209,10 +210,9 @@ enforcer:
   # If false, enforcer will not be installed
   enabled: true
   image:
-    repository: neuvector/enforcer
+    repository: suse/neuvector/enforcer
+    tag: 5.0.5
     hash:
-  updateStrategy:
-    type: RollingUpdate
   priorityClassName:
   podLabels: {}
   podAnnotations: {}
@@ -233,8 +233,9 @@ manager:
   # If false, manager will not be installed
   enabled: true
   image:
-    repository: neuvector/manager
-    hash:
+    repository: suse/neuvector/manager
+    tag: 5.0.3
+    hash: sha256:eee3b7001135ff3caed6b5125bd0843ae528302f8bf31f584470013d060a5241
   priorityClassName:
   env:
     ssl: true
@@ -303,9 +304,9 @@ cve:
     enabled: true
     secure: false
     image:
-      repository: neuvector/updater
-      tag: latest
-      hash:
+      repository: suse/neuvector/updater
+      tag: 5
+      hash: sha256:802c37b0b756bd254dc9605436d5bd66009de4b4bfdb631762c356a3f608674c
     schedule: "0 0 * * *"
     priorityClassName:
     podLabels: {}
@@ -324,9 +325,9 @@ cve:
         maxSurge: 1
         maxUnavailable: 0
     image:
-      repository: neuvector/scanner
-      tag: latest
-      hash:
+      repository: suse/neuvector/scanner
+      tag: 5
+      hash: sha256:b8850536d05a17b18ba3832b0c8b8390d4ab4580c974173b03937cc9d963fd00
     priorityClassName:
     resources: {}
       # limits:
@@ -359,7 +360,7 @@ k3s:
   runtimePath: /run/k3s/containerd/containerd.sock
 
 bottlerocket:
-  enabled: true
+  enabled: false
   runtimePath: /run/dockershim.sock
 
 containerd:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -4,7 +4,7 @@
 
 openshift: false
 
-registry: docker.io
+registry: 709825985650.dkr.ecr.us-east-1.amazonaws.com/suse
 tag: 5.0.5
 oem:
 imagePullSecrets:
@@ -252,16 +252,16 @@ manager:
     termination: passthrough
     host:
     tls:
-      #certificate: | 
+      #certificate: |
       #  -----BEGIN CERTIFICATE-----
       #  -----END CERTIFICATE-----
-      #caCertificate: | 
+      #caCertificate: |
       #  -----BEGIN CERTIFICATE-----
       #  -----END CERTIFICATE-----
-      #destinationCACertificate: | 
+      #destinationCACertificate: |
       #  -----BEGIN CERTIFICATE-----
       #  -----END CERTIFICATE-----
-      #key: | 
+      #key: |
       #  -----BEGIN PRIVATE KEY-----
       #  -----END PRIVATE KEY-----
   certificate:
@@ -359,7 +359,7 @@ k3s:
   runtimePath: /run/k3s/containerd/containerd.sock
 
 bottlerocket:
-  enabled: false
+  enabled: true
   runtimePath: /run/dockershim.sock
 
 containerd:


### PR DESCRIPTION
Rebased from neuvector/neuvector-helm master; updated to v5.0.5.

ECR listings for each container follow, so you can verify tags & checksums in the PR.

```
$ aws --profile mp-images-us ecr describe-images --registry-id 709825985650 --repository-name suse/neuvector/controller --image-ids imageTag=5.0.5 --region us-east-1
{
    "imageDetails": [
        {
            "registryId": "709825985650",
            "repositoryName": "suse/neuvector/controller",
            "imageDigest": "sha256:761a1cfcfe3228fe3b4a60b9eef3cf1b33065c427839024a52c8ce1c7acd0af1",
            "imageTags": [
                "5.0.5"
            ],
            "imageSizeInBytes": 75765927,
            "imagePushedAt": "2022-11-29T10:19:10-08:00",
            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
        }
    ]
}
```

```
$ aws --profile mp-images-us ecr describe-images --registry-id 709825985650 --repository-name suse/neuvector/enforcer --image-ids imageTag=5.0.5 --region us-east-1
{
    "imageDetails": [
        {
            "registryId": "709825985650",
            "repositoryName": "suse/neuvector/enforcer",
            "imageDigest": "sha256:17554ce765d144c417569041a9599f3a7132e6f66e2ac19bb0d45f5919abbc72",
            "imageTags": [
                "5.0.5"
            ],
            "imageSizeInBytes": 86262057,
            "imagePushedAt": "2022-11-29T10:22:05-08:00",
            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
        }
    ]
}
```

```
$ aws --profile mp-images-us ecr describe-images --registry-id 709825985650 --repository-name suse/neuvector/manager --image-ids imageTag=5.0.5 --region us-east-1
{
    "imageDetails": [
        {
            "registryId": "709825985650",
            "repositoryName": "suse/neuvector/manager",
            "imageDigest": "sha256:6df964f1ea419f8590b865cd95e26db1c08da6e6a432305100e0755f6d1fb912",
            "imageTags": [
                "5.0.5"
            ],
            "imageSizeInBytes": 274562576,
            "imagePushedAt": "2022-11-29T10:27:08-08:00",
            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
        }
    ]
}
```

```
$ aws --profile mp-images-us ecr describe-images --registry-id 709825985650 --repository-name suse/neuvector/updater --image-ids imageTag=5.0.20221129 --region us-east-1
{
    "imageDetails": [
        {
            "registryId": "709825985650",
            "repositoryName": "suse/neuvector/updater",
            "imageDigest": "sha256:ef98e30e0811dfcdb47e86807f4a8e2bb7dfc7975109cca85b1b4cc9412ab226",
            "imageTags": [
                "5.0.20221129"
            ],
            "imageSizeInBytes": 5794563,
            "imagePushedAt": "2022-11-29T10:32:02-08:00",
            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
        }
    ]
}
```

```
$ aws --profile mp-images-us ecr describe-images --registry-id 709825985650 --repository-name suse/neuvector/scanner --image-ids imageTag=5.0.20221129 --region us-east-1
{
    "imageDetails": [
        {
            "registryId": "709825985650",
            "repositoryName": "suse/neuvector/scanner",
            "imageDigest": "sha256:54dd64bff2679baa6a1644c392ea7eaaa9f1c1e9111ab8b04c66d8454d648cff",
            "imageTags": [
                "5.0.20221129"
            ],
            "imageSizeInBytes": 109836383,
            "imagePushedAt": "2022-11-29T10:36:02-08:00",
            "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "artifactMediaType": "application/vnd.docker.container.image.v1+json"
        }
    ]
}
```