### PR TITLE
Missing containerd.sock is CrashLoopBackOff

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -128,9 +128,9 @@ spec:
               name: nv-share
               readOnly: false
           {{- if .Values.containerd.enabled }}
-            - mountPath: /var/run/containerd/
+            - mountPath: /var/run/containerd/containerd.sock
           {{- else if .Values.k3s.enabled }}
-            - mountPath: /var/run/containerd/
+            - mountPath: /var/run/containerd/containerd.sock
           {{- else if .Values.bottlerocket.enabled }}
             - mountPath: /var/run/containerd/containerd.sock
           {{- else if .Values.crio.enabled }}

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -83,9 +83,9 @@ spec:
           {{- end }}
           volumeMounts:
           {{- if .Values.containerd.enabled }}
-            - mountPath: /var/run/containerd/
+            - mountPath: /var/run/containerd/containerd.sock
           {{- else if .Values.k3s.enabled }}
-            - mountPath: /var/run/containerd/
+            - mountPath: /var/run/containerd/containerd.sock
           {{- else if .Values.bottlerocket.enabled }}
             - mountPath: /var/run/containerd/containerd.sock
           {{- else if .Values.crio.enabled }}


### PR DESCRIPTION
In the latest `2.4.4` chart the controller and enforcer are missing the 'containerd.sock' fields in the volume mounts. 

Testing
Working:
```
helm upgrade -i neuvector -n neuvector neuvector/core --version 2.4.3 --create-namespace --set imagePullSecrets=regsecret --set k3s.enabled=true --set k3s.runtimePath=/run/k3s/containerd/containerd.sock --set manager.ingress.enabled=true --set manager.ingress.host=neuvector.rfed.io --set manager.svc.type=ClusterIP
```

Not working:
```
helm upgrade -i neuvector -n neuvector neuvector/core --version 2.4.4 --create-namespace --set imagePullSecrets=regsecret --set k3s.enabled=true --set k3s.runtimePath=/run/k3s/containerd/containerd.sock --set manager.ingress.enabled=true --set manager.ingress.host=neuvector.rfed.io --set manager.svc.type=ClusterIP
```
