### PR TITLE
Add cacert on updater

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -187,7 +187,8 @@ Parameter | Description | Default | Notes
 `cve.adapter.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
 `cve.adapter.runAsUser` | Specify the run as User ID | `nil` |
 `cve.updater.enabled` | If true, create cve updater | `true` |
-`cve.updater.secure` | If ture, API server's certificate is validated  | `false` |
+`cve.updater.secure` | If true, API server's certificate is validated  | `false` |
+`cve.updater.cacert` | If set, use this ca file to validate API server's certificate  | `nil` |
 `cve.updater.image.registry` | cve updater image registry to overwrite global registry | |
 `cve.updater.image.repository` | cve updater image repository | `neuvector/updater` |
 `cve.updater.image.tag` | image tag for cve updater | `latest` |

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -188,7 +188,7 @@ Parameter | Description | Default | Notes
 `cve.adapter.runAsUser` | Specify the run as User ID | `nil` |
 `cve.updater.enabled` | If true, create cve updater | `true` |
 `cve.updater.secure` | If true, API server's certificate is validated  | `false` |
-`cve.updater.cacert` | If set, use this ca file to validate API server's certificate  | `nil` |
+`cve.updater.cacert` | If set, use this ca file to validate API server's certificate  | `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` |
 `cve.updater.image.registry` | cve updater image registry to overwrite global registry | |
 `cve.updater.image.repository` | cve updater image repository | `neuvector/updater` |
 `cve.updater.image.tag` | image tag for cve updater | `latest` |

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -77,7 +77,11 @@ spec:
               - -c
             {{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
               {{- if .Values.cve.updater.secure }}
-              - /usr/bin/curl -v --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              {{- if .Values.cve.updater.cacert }}
+              - /usr/bin/curl -v --cacert {{ .Values.cve.updater.cacert }} -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              {{- else }}
+              - /usr/bin/curl -v -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              {{- end }}
               {{- else }}
               - /usr/bin/curl -kv -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
               {{- end }}

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -77,7 +77,7 @@ spec:
               - -c
             {{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
               {{- if .Values.cve.updater.secure }}
-              - /usr/bin/curl -v -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              - /usr/bin/curl -v --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
               {{- else }}
               - /usr/bin/curl -kv -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
               {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -408,7 +408,7 @@ cve:
     # If false, cve updater will not be installed
     enabled: true
     secure: false
-    cacert:
+    cacert: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     image:
       registry: ""
       repository: neuvector/updater

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -408,6 +408,7 @@ cve:
     # If false, cve updater will not be installed
     enabled: true
     secure: false
+    cacert:
     image:
       registry: ""
       repository: neuvector/updater


### PR DESCRIPTION

On my configuration (OCP4) I got an issue with the pod updater, curl say the following error :

try a curl like the command on charts/core/templates/updater-cronjob.yaml:83 : 
```
$ curl -v https://kubernetes.default/apis/apps/v1/namespaces
* processing: https://kubernetes.default/apis/apps/v1/namespaces
*   Trying 172.30.0.1:443...
* Connected to kubernetes.default (172.30.0.1) port 443
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: none
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Request CERT (13):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (OUT), TLS alert, unknown CA (560):
* SSL certificate problem: self-signed certificate in certificate chain
* Closing connection
curl: (60) SSL certificate problem: self-signed certificate in certificate chain
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

If we specify certificate, there is no cert error : 

```
$ curl --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default/apis/apps/v1/namespaces
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "namespaces.apps is forbidden: User \"system:anonymous\" cannot list resource \"namespaces\" in API group \"apps\" at the cluster scope",
  "reason": "Forbidden",
  "details": {
    "group": "apps",
    "kind": "namespaces"
  },
  "code": 403
```

This is because the certificate is not expicit.

This MR add a cacert on the secure curl command.
