### PR TITLE
add to support initial admin password for cloud team and native k8s setup

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -205,10 +205,10 @@ controller:
   secret:
     # NOTE: files defined here have preferrence over the ones defined in the configmap section
     enabled: false
-    data: {}
-      # passwordprofileinitcfg.yaml: |
+    data:
+      # passwordprofileinitcfg.yaml:
       #  ...
-      # roleinitcfg.yaml: |
+      # roleinitcfg.yaml:
       #  ...
       # ldapinitcfg.yaml:
       #   directory: OpenLDAP
@@ -220,8 +220,11 @@ controller:
       #   ...
       # sysinitcfg.yaml:
       #   ...
-      # userinitcfg.yaml:
-      #   ...
+      userinitcfg.yaml:
+        users:
+        - Fullname: admin
+          Password:
+          Role: admin
 
 enforcer:
   # If false, enforcer will not be installed


### PR DESCRIPTION
for native k8s setup, do nothing.
for cloud team, change the value of controller.secret.enabled to true and run below command to deploy neuvector to set initial admin password

helm install --set 'controller.secret.data.userinitcfg\.yaml.users[0].Password=xxx' myapp .