### PR TITLE
NVSHAS-8212: use self-signed certs by default

### DIFF
--- a/charts/core/templates/controller-secret.yaml
+++ b/charts/core/templates/controller-secret.yaml
@@ -1,9 +1,7 @@
 {{- if .Values.controller.enabled -}}
 {{- if .Values.autoGenerateCert }}
 {{- $cn := "neuvector" }}
-{{- $ca := genCA (printf "%s-ca" "neuvector") (.Values.defaultValidityPeriod | int) -}}
-{{- $cert := genSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) $ca -}}
-{{- $signingCert := genSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) $ca -}}
+{{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/core/templates/manager-secret.yaml
+++ b/charts/core/templates/manager-secret.yaml
@@ -1,8 +1,7 @@
 {{- if .Values.manager.enabled -}}
 {{- if .Values.autoGenerateCert }}
 {{- $cn := "neuvector" }}
-{{- $ca := genCA (printf "%s-ca" "neuvector") (.Values.defaultValidityPeriod | int) -}}
-{{- $cert := genSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) $ca -}}
+{{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/core/templates/registry-adapter-secret.yaml
+++ b/charts/core/templates/registry-adapter-secret.yaml
@@ -1,8 +1,7 @@
 {{- if .Values.cve.adapter.enabled -}}
 {{- if .Values.autoGenerateCert }}
 {{- $cn := "neuvector" }}
-{{- $ca := genCA (printf "%s-ca" "neuvector") (.Values.defaultValidityPeriod | int) -}}
-{{- $cert := genSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) $ca -}}
+{{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
We don't need to generate a one-time ca to sign default certs here.  Use a self-signed certs instead to make code clearer. 