### PR TITLE
Option to add annotations to monitor grafana dashboard

### DIFF
--- a/charts/monitor/templates/dashboard.yaml
+++ b/charts/monitor/templates/dashboard.yaml
@@ -9,6 +9,10 @@ metadata:
 {{- if .Values.exporter.grafanaDashboard.labels }}
     {{- toYaml .Values.exporter.grafanaDashboard.labels | nindent 4}}
 {{- end }}
+{{- if .Values.exporter.grafanaDashboard.annotations }}
+  annotations:
+    {{- toYaml .Values.exporter.grafanaDashboard.annotations | nindent 4}}
+{{- end }}
 data:
   nv_dashboard.json: |
 {{ .Files.Get "dashboards/nv_dashboard.json" | indent 4 }}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -30,6 +30,8 @@ exporter:
     enabled: false
     namespace: "" # Release namespace, if empty
     labels: {}
+    # annotations: {}
+      # k8s-sidecar-target-directory: /tmp/dashboards/neuvector
 
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
Following the suggestion from this issue, this PR adds an option to add annotations into dashboard from monitor Chart. Also bumps the chart minor version, if its not needed it can be removed.


https://github.com/neuvector/neuvector-helm/issues/319
