### PR TITLE
Remove resource kind from resource names

### DIFF
--- a/charts/core/templates/NOTES.txt
+++ b/charts/core/templates/NOTES.txt
@@ -4,17 +4,17 @@ http://{{ .Values.manager.ingress.host }}
 {{- else if not .Values.openshift }}
 Get the NeuVector URL by running these commands:
 {{- if contains "NodePort" .Values.manager.svc.type }}
-  NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services neuvector-service-webui)
+  NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services neuvector-webui)
   NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo https://$NODE_IP:$NODE_PORT
 {{- else if contains "ClusterIP" .Values.manager.svc.type }}
-  CLUSTER_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.clusterIP}" services neuvector-service-webui)
+  CLUSTER_IP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.clusterIP}" services neuvector-webui)
   echo https://$CLUSTER_IP:8443
 {{- else if contains "LoadBalancer" .Values.manager.svc.type }}
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w neuvector-service-webui'
+        Watch the status by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w neuvector-webui'
 
-  SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} neuvector-service-webui -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+  SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} neuvector-webui -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
   echo https://$SERVICE_IP:8443
 {{- end }}
 {{- end }}

--- a/charts/core/templates/admission-webhook-service.yaml
+++ b/charts/core/templates/admission-webhook-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-svc-admission-webhook
+  name: neuvector-admission-webhook
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/core/templates/admission-webhook-service.yaml
+++ b/charts/core/templates/admission-webhook-service.yaml
@@ -15,4 +15,4 @@ spec:
       name: admission-webhook
   type: {{ .Values.admissionwebhook.type }}
   selector:
-    app: neuvector-controller-pod
+    app: neuvector-controller

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -6,7 +6,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Deployment
 metadata:
-  name: neuvector-controller-pod
+  name: neuvector-controller
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -78,7 +78,7 @@ spec:
       serviceAccount: {{ .Values.serviceAccount }}
       {{- end }}
       containers:
-        - name: neuvector-controller-pod
+        - name: neuvector-controller
           {{- if .Values.global.azure.enabled }}
           image: "{{ .Values.global.azure.images.controller.registry }}/{{ .Values.global.azure.images.controller.image }}@{{ .Values.global.azure.images.controller.digest }}"
           {{- else }}

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -23,11 +23,11 @@ spec:
 {{ toYaml .Values.controller.strategy | indent 4 }}
   selector:
     matchLabels:
-      app: neuvector-controller-pod
+      app: neuvector-controller
   template:
     metadata:
       labels:
-        app: neuvector-controller-pod
+        app: neuvector-controller
         release: {{ .Release.Name }}
         {{- with .Values.controller.podLabels }}
         {{- toYaml . | nindent 8 }}
@@ -287,6 +287,6 @@ spec:
   minAvailable: {{ .Values.controller.disruptionbudget }}
   selector:
     matchLabels:
-      app: neuvector-controller-pod
+      app: neuvector-controller
 {{- end }}
 {{- end }}

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -113,7 +113,7 @@ spec:
             periodSeconds: 5
           env:
             - name: CLUSTER_JOIN_ADDR
-              value: neuvector-svc-controller.{{ .Release.Namespace }}
+              value: neuvector-controller.{{ .Release.Namespace }}
             - name: CLUSTER_ADVERTISED_ADDR
               valueFrom:
                 fieldRef:

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -260,7 +260,7 @@ spec:
       {{- if .Values.autoGenerateCert }}
         - name: cert
           secret:
-            secretName: neuvector-controller-secret
+            secretName: neuvector-controller
       {{- end }}
       {{- if .Values.controller.certificate.secret }}
         - name: usercert

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -260,7 +260,7 @@ spec:
       {{- if .Values.autoGenerateCert }}
         - name: cert
           secret:
-            secretName: neuvector-controller
+            secretName: neuvector-controller-secret
       {{- end }}
       {{- if .Values.controller.certificate.secret }}
         - name: usercert

--- a/charts/core/templates/controller-ingress.yaml
+++ b/charts/core/templates/controller-ingress.yaml
@@ -34,7 +34,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: neuvector-svc-controller-api
+            name: neuvector-controller-api
             port:
               number: 10443
 {{- else }}
@@ -66,7 +66,7 @@ spec:
       paths:
       - path: {{ .Values.controller.ingress.path }}
         backend:
-          serviceName: neuvector-svc-controller-api
+          serviceName: neuvector-controller-api
           servicePort: 10443
 {{- end }}
 {{- end }}
@@ -106,7 +106,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: neuvector-svc-controller-fed-master
+            name: neuvector-controller-fed-master
             port:
               number: 11443
 {{- else }}
@@ -139,7 +139,7 @@ spec:
       paths:
       - path: {{ .Values.controller.federation.mastersvc.ingress.path }}
         backend:
-          serviceName: neuvector-svc-controller-fed-master
+          serviceName: neuvector-controller-fed-master
           servicePort: 11443
 {{- end }}
 {{- end }}
@@ -179,7 +179,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: neuvector-svc-controller-fed-managed
+            name: neuvector-controller-fed-managed
             port:
               number: 10443
 {{- else }}
@@ -212,7 +212,7 @@ spec:
       paths:
       - path: {{ .Values.controller.federation.managedsvc.ingress.path }}
         backend:
-          serviceName: neuvector-svc-controller-fed-managed
+          serviceName: neuvector-controller-fed-managed
           servicePort: 10443
 {{- end }}
 {{- end }}

--- a/charts/core/templates/controller-route.yaml
+++ b/charts/core/templates/controller-route.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   to:
     kind: Service
-    name: neuvector-svc-controller-api
+    name: neuvector-controller-api
   port:
     targetPort: controller-api
   tls:
@@ -52,7 +52,7 @@ spec:
 {{- end }}
   to:
     kind: Service
-    name: neuvector-svc-controller-fed-master
+    name: neuvector-controller-fed-master
   port:
     targetPort: fed
   tls:
@@ -84,7 +84,7 @@ spec:
 {{- end }}
   to:
     kind: Service
-    name: neuvector-svc-controller-fed-managed
+    name: neuvector-controller-fed-managed
   port:
     targetPort: fed
   tls:

--- a/charts/core/templates/controller-secret.yaml
+++ b/charts/core/templates/controller-secret.yaml
@@ -5,11 +5,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-controller
+  name: neuvector-controller-secret
 type: Opaque
 data:
-  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
-  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
+  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
+  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller-secret" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
 ---
 {{- end}}
 {{- end}}

--- a/charts/core/templates/controller-secret.yaml
+++ b/charts/core/templates/controller-secret.yaml
@@ -5,11 +5,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-controller-secret
+  name: neuvector-controller
 type: Opaque
 data:
-  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
-  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller-secret" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
+  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
+  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
 ---
 {{- end}}
 {{- end}}

--- a/charts/core/templates/controller-service.yaml
+++ b/charts/core/templates/controller-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-svc-controller
+  name: neuvector-controller
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -27,7 +27,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-svc-controller-api
+  name: neuvector-controller-api
   namespace: {{ .Release.Namespace }}
 {{- with .Values.controller.apisvc.annotations }}
   annotations:
@@ -51,7 +51,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-svc-controller-fed-master
+  name: neuvector-controller-fed-master
   namespace: {{ .Release.Namespace }}
 {{- with .Values.controller.federation.mastersvc.annotations }}
   annotations:
@@ -75,7 +75,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-svc-controller-fed-managed
+  name: neuvector-controller-fed-managed
   namespace: {{ .Release.Namespace }}
 {{- with .Values.controller.federation.managedsvc.annotations }}
   annotations:

--- a/charts/core/templates/controller-service.yaml
+++ b/charts/core/templates/controller-service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: "UDP"
       name: "cluster-udp-18301"
   selector:
-    app: neuvector-controller-pod
+    app: neuvector-controller
 {{- if .Values.controller.apisvc.type }}
 ---
 apiVersion: v1
@@ -44,7 +44,7 @@ spec:
       protocol: "TCP"
       name: "controller-api"
   selector:
-    app: neuvector-controller-pod
+    app: neuvector-controller
 {{ end -}}
 {{- if .Values.controller.federation.mastersvc.type }}
 ---
@@ -68,7 +68,7 @@ spec:
     name: fed
     protocol: TCP
   selector:
-    app: neuvector-controller-pod
+    app: neuvector-controller
 {{ end -}}
 {{- if .Values.controller.federation.managedsvc.type }}
 ---
@@ -92,6 +92,6 @@ spec:
     name: fed
     protocol: TCP
   selector:
-    app: neuvector-controller-pod
+    app: neuvector-controller
 {{ end -}}
 {{- end -}}

--- a/charts/core/templates/crd.yaml
+++ b/charts/core/templates/crd.yaml
@@ -827,7 +827,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-svc-crd-webhook
+  name: neuvector-crd-webhook
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/core/templates/crd.yaml
+++ b/charts/core/templates/crd.yaml
@@ -841,5 +841,5 @@ spec:
       name: crd-webhook
   type: {{ .Values.crdwebhook.type }}
   selector:
-    app: neuvector-controller-pod
+    app: neuvector-controller
 {{- end }}

--- a/charts/core/templates/csp-deployment.yaml
+++ b/charts/core/templates/csp-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: neuvector-csp-pod
+  name: neuvector-csp
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -57,7 +57,7 @@ spec:
         {{- else if and .Values.global.azure.enabled }}
         image: "{{ .Values.global.azure.images.neuvector_csp_pod.registry }}/{{ .Values.global.azure.images.neuvector_csp_pod.image }}@{{ .Values.global.azure.images.neuvector_csp_pod.digest }}"
         {{- end }}
-        name: neuvector-csp-pod
+        name: neuvector-csp
         {{- if .Values.global.aws.enabled }}
         imagePullPolicy: "{{ .Values.global.aws.image.imagePullPolicy }}"
         {{- else if .Values.global.azure.enabled }}

--- a/charts/core/templates/csp-deployment.yaml
+++ b/charts/core/templates/csp-deployment.yaml
@@ -15,11 +15,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: neuvector-csp-pod
+      app: neuvector-csp
   template:
     metadata:
       labels:
-        app: neuvector-csp-pod
+        app: neuvector-csp
         release: {{ .Release.Name }}
     spec:
       {{- if .Values.global.aws.imagePullSecrets }}

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -78,7 +78,7 @@ spec:
           {{- end }}
           env:
             - name: CLUSTER_JOIN_ADDR
-              value: neuvector-svc-controller.{{ .Release.Namespace }}
+              value: neuvector-controller.{{ .Release.Namespace }}
             - name: CLUSTER_ADVERTISED_ADDR
               valueFrom:
                 fieldRef:

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -16,11 +16,11 @@ spec:
   updateStrategy: {{- toYaml .Values.enforcer.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
-      app: neuvector-enforcer-pod
+      app: neuvector-enforcer
   template:
     metadata:
       labels:
-        app: neuvector-enforcer-pod
+        app: neuvector-enforcer
         release: {{ .Release.Name }}
         {{- with .Values.enforcer.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -6,7 +6,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: DaemonSet
 metadata:
-  name: neuvector-enforcer-pod
+  name: neuvector-enforcer
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -50,7 +50,7 @@ spec:
       serviceAccount: {{ .Values.serviceAccount }}
     {{- end }}
       containers:
-        - name: neuvector-enforcer-pod
+        - name: neuvector-enforcer
           {{- if .Values.global.azure.enabled }}
           image: "{{ .Values.global.azure.images.enforcer.registry }}/{{ .Values.global.azure.images.enforcer.image }}@{{ .Values.global.azure.images.enforcer.digest }}"
           {{- else }}

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -6,7 +6,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Deployment
 metadata:
-  name: neuvector-manager-pod
+  name: neuvector-manager
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -66,7 +66,7 @@ spec:
         runAsUser: {{ .Values.manager.runAsUser }}
       {{- end }}
       containers:
-        - name: neuvector-manager-pod
+        - name: neuvector-manager
           {{- if .Values.global.azure.enabled }}
           image: "{{ .Values.global.azure.images.manager.registry }}/{{ .Values.global.azure.images.manager.image }}@{{ .Values.global.azure.images.manager.digest }}"
           {{- else }}

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -86,7 +86,7 @@ spec:
           {{- end }}
           env:
             - name: CTRL_SERVER_IP
-              value: neuvector-svc-controller.{{ .Release.Namespace }}
+              value: neuvector-controller.{{ .Release.Namespace }}
             {{- if not .Values.manager.env.ssl }}
             - name: MANAGER_SSL
               value: "off"

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -129,6 +129,6 @@ spec:
       {{- else if .Values.autoGenerateCert }}
         - name: cert
           secret:
-            secretName: neuvector-manager
+            secretName: neuvector-manager-secret
       {{- end }}
 {{- end }}

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -16,11 +16,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: neuvector-manager-pod
+      app: neuvector-manager
   template:
     metadata:
       labels:
-        app: neuvector-manager-pod
+        app: neuvector-manager
         release: {{ .Release.Name }}
         {{- with .Values.manager.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -129,6 +129,6 @@ spec:
       {{- else if .Values.autoGenerateCert }}
         - name: cert
           secret:
-            secretName: neuvector-manager-secret
+            secretName: neuvector-manager
       {{- end }}
 {{- end }}

--- a/charts/core/templates/manager-ingress.yaml
+++ b/charts/core/templates/manager-ingress.yaml
@@ -33,7 +33,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: neuvector-service-webui
+            name: neuvector-webui
             port:
               number: 8443
 {{- else }}
@@ -65,7 +65,7 @@ spec:
       paths:
       - path: {{ .Values.manager.ingress.path }}
         backend:
-          serviceName: neuvector-service-webui
+          serviceName: neuvector-webui
           servicePort: 8443
 {{- end }}
 {{- end -}}

--- a/charts/core/templates/manager-route.yaml
+++ b/charts/core/templates/manager-route.yaml
@@ -19,7 +19,7 @@ spec:
 {{- end }}
   to:
     kind: Service
-    name: neuvector-service-webui
+    name: neuvector-webui
   port:
     targetPort: manager
   tls:

--- a/charts/core/templates/manager-secret.yaml
+++ b/charts/core/templates/manager-secret.yaml
@@ -5,11 +5,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-manager-secret
+  name: neuvector-manager
 type: Opaque
 data:
-  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
-  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager-secret" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
+  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
+  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/core/templates/manager-secret.yaml
+++ b/charts/core/templates/manager-secret.yaml
@@ -5,11 +5,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-manager
+  name: neuvector-manager-secret
 type: Opaque
 data:
-  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
-  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
+  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
+  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-manager-secret" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/core/templates/manager-service.yaml
+++ b/charts/core/templates/manager-service.yaml
@@ -22,5 +22,5 @@ spec:
       name: manager
       protocol: TCP
   selector:
-    app: neuvector-manager-pod
+    app: neuvector-manager
 {{- end }}

--- a/charts/core/templates/manager-service.yaml
+++ b/charts/core/templates/manager-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-service-webui
+  name: neuvector-webui
   namespace: {{ .Release.Namespace }}
 {{- with .Values.manager.svc.annotations }}
   annotations:

--- a/charts/core/templates/registry-adapter-ingress.yaml
+++ b/charts/core/templates/registry-adapter-ingress.yaml
@@ -67,7 +67,7 @@ spec:
       paths:
       - path: {{ .Values.cve.adapter.ingress.path }}
         backend:
-          serviceName: neuvector-service-webui
+          serviceName: neuvector-webui
           servicePort: 9443
 {{- end }}
 {{- end }}

--- a/charts/core/templates/registry-adapter-secret.yaml
+++ b/charts/core/templates/registry-adapter-secret.yaml
@@ -5,11 +5,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-registry-adapter
+  name: neuvector-registry-adapter-secret
 type: Opaque
 data:
-  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
-  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
+  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
+  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter-secret" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/core/templates/registry-adapter-secret.yaml
+++ b/charts/core/templates/registry-adapter-secret.yaml
@@ -5,11 +5,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-registry-adapter-secret
+  name: neuvector-registry-adapter
 type: Opaque
 data:
-  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
-  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter-secret" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
+  ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
+  ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -82,7 +82,7 @@ spec:
           {{- end }}
           env:
             - name: CLUSTER_JOIN_ADDR
-              value: neuvector-svc-controller.{{ .Release.Namespace }}
+              value: neuvector-controller.{{ .Release.Namespace }}
             - name: HARBOR_SERVER_PROTO
               value: {{ .Values.cve.adapter.harbor.protocol }}
             {{- if .Values.cve.adapter.harbor.secretName }}

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -150,7 +150,7 @@ spec:
       {{- else if .Values.autoGenerateCert }}
         - name: cert
           secret:
-            secretName: neuvector-registry-adapter
+            secretName: neuvector-registry-adapter-secret
       {{- end }}
       {{- if .Values.internal.certmanager.enabled }}
         - name: internal-cert

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -16,11 +16,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: neuvector-registry-adapter-pod
+      app: neuvector-registry-adapter
   template:
     metadata:
       labels:
-        app: neuvector-registry-adapter-pod
+        app: neuvector-registry-adapter
         release: {{ .Release.Name }}
         {{- with .Values.cve.adapter.podLabels }}
         {{- toYaml . | nindent 8 }}
@@ -187,6 +187,6 @@ spec:
 {{- end }}
       protocol: TCP
   selector:
-    app: neuvector-registry-adapter-pod
+    app: neuvector-registry-adapter
 
 {{- end }}

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -6,7 +6,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Deployment
 metadata:
-  name: neuvector-registry-adapter-pod
+  name: neuvector-registry-adapter
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -66,7 +66,7 @@ spec:
         runAsUser: {{ .Values.cve.adapter.runAsUser }}
       {{- end }}
       containers:
-        - name: neuvector-registry-adapter-pod
+        - name: neuvector-registry-adapter
           {{- if eq .Values.registry "registry.neuvector.com" }}
           {{- if .Values.oem }}
           image: "{{ .Values.registry }}/{{ .Values.oem }}/registry-adapter:{{ .Values.cve.adapter.image.tag }}"

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -150,7 +150,7 @@ spec:
       {{- else if .Values.autoGenerateCert }}
         - name: cert
           secret:
-            secretName: neuvector-registry-adapter-secret
+            secretName: neuvector-registry-adapter
       {{- end }}
       {{- if .Values.internal.certmanager.enabled }}
         - name: internal-cert

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -6,7 +6,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Deployment
 metadata:
-  name: neuvector-scanner-pod
+  name: neuvector-scanner
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -62,7 +62,7 @@ spec:
         runAsUser: {{ .Values.cve.scanner.runAsUser }}
       {{- end }}
       containers:
-        - name: neuvector-scanner-pod
+        - name: neuvector-scanner
           {{- if .Values.global.azure.enabled }}
           image: "{{ .Values.global.azure.images.scanner.registry }}/{{ .Values.global.azure.images.scanner.image }}@{{ .Values.global.azure.images.scanner.digest }}"
           {{- else }}

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -85,7 +85,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: CLUSTER_JOIN_ADDR
-              value: neuvector-svc-controller.{{ .Release.Namespace }}
+              value: neuvector-controller.{{ .Release.Namespace }}
           {{- if .Values.cve.scanner.dockerPath }}
             - name: SCANNER_DOCKER_URL
               value: {{ .Values.cve.scanner.dockerPath }}

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -18,11 +18,11 @@ spec:
   replicas: {{ .Values.cve.scanner.replicas }}
   selector:
     matchLabels:
-      app: neuvector-scanner-pod
+      app: neuvector-scanner
   template:
     metadata:
       labels:
-        app: neuvector-scanner-pod
+        app: neuvector-scanner
         {{- with .Values.cve.scanner.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -21,7 +21,7 @@ spec:
       template:
         metadata:
           labels:
-            app: neuvector-updater-pod
+            app: neuvector-updater
             release: {{ .Release.Name }}
             {{- with .Values.cve.updater.podLabels }}
             {{- toYaml . | nindent 12 }}

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -8,7 +8,7 @@ apiVersion: batch/v2alpha1
 {{- end }}
 kind: CronJob
 metadata:
-  name: neuvector-updater-pod
+  name: neuvector-updater
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -54,7 +54,7 @@ spec:
             runAsUser: {{ .Values.cve.updater.runAsUser }}
           {{- end }}
           containers:
-            - name: neuvector-updater-pod
+            - name: neuvector-updater
               {{- if eq .Values.registry "registry.neuvector.com" }}
               {{- if .Values.oem }}
               image: "{{ .Values.registry }}/{{ .Values.oem }}/updater:{{ .Values.cve.updater.image.tag }}"

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -78,15 +78,15 @@ spec:
             {{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
               {{- if .Values.cve.updater.secure }}
               {{- if .Values.cve.updater.cacert }}
-              - /usr/bin/curl -v --cacert {{ .Values.cve.updater.cacert }} -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              - /usr/bin/curl -v --cacert {{ .Values.cve.updater.cacert }} -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner'
               {{- else }}
-              - /usr/bin/curl -v -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              - /usr/bin/curl -v -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner'
               {{- end }}
               {{- else }}
-              - /usr/bin/curl -kv -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              - /usr/bin/curl -kv -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/apps/v1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner'
               {{- end }}
             {{- else }}
-              - /usr/bin/curl -kv -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/extensions/v1beta1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner-pod'
+              - /usr/bin/curl -kv -X PATCH -H "Authorization:Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -H "Content-Type:application/strategic-merge-patch+json" -d '{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"'`date +%Y-%m-%dT%H:%M:%S%z`'"}}}}}' 'https://kubernetes.default/apis/extensions/v1beta1/namespaces/{{ .Release.Namespace }}/deployments/neuvector-scanner'
             {{- end }}
           {{- end }}
           restartPolicy: Never

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -99,7 +99,7 @@ controller:
                 - key: app
                   operator: In
                   values:
-                    - neuvector-controller-pod
+                    - neuvector-controller
             topologyKey: "kubernetes.io/hostname"
   tolerations: []
   nodeSelector:

--- a/charts/crd/templates/crd.yaml
+++ b/charts/crd/templates/crd.yaml
@@ -840,4 +840,4 @@ spec:
       name: crd-webhook
   type: {{ .Values.crdwebhook.type }}
   selector:
-    app: neuvector-controller-pod
+    app: neuvector-controller

--- a/charts/crd/templates/crd.yaml
+++ b/charts/crd/templates/crd.yaml
@@ -826,7 +826,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: neuvector-svc-crd-webhook
+  name: neuvector-crd-webhook
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -51,6 +51,6 @@ spec:
               value: "8068"
           envFrom:
             - secretRef:
-                name: neuvector-prometheus-exporter
+                name: neuvector-prometheus-exporter-pod
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -51,6 +51,6 @@ spec:
               value: "8068"
           envFrom:
             - secretRef:
-                name: neuvector-prometheus-exporter-pod-secret
+                name: neuvector-prometheus-exporter-pod
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -51,6 +51,6 @@ spec:
               value: "8068"
           envFrom:
             - secretRef:
-                name: neuvector-prometheus-exporter-pod
+                name: neuvector-prometheus-exporter
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -51,6 +51,6 @@ spec:
               value: "8068"
           envFrom:
             - secretRef:
-                name: neuvector-prometheus-exporter-secret
+                name: neuvector-prometheus-exporter
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -51,6 +51,6 @@ spec:
               value: "8068"
           envFrom:
             - secretRef:
-                name: neuvector-prometheus-exporter-pod
+                name: neuvector-prometheus-exporter-pod-secret
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -51,6 +51,6 @@ spec:
               value: "8068"
           envFrom:
             - secretRef:
-                name: neuvector-prometheus-exporter-pod-secret
+                name: neuvector-prometheus-exporter-secret
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: neuvector-prometheus-exporter-pod
+  name: neuvector-prometheus-exporter
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}
@@ -12,7 +12,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: neuvector-prometheus-exporter-pod
+      app: neuvector-prometheus-exporter
   template:
     metadata:
       annotations:
@@ -21,7 +21,7 @@ spec:
         prometheus.io/scrape: "true"
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
-        app: neuvector-prometheus-exporter-pod
+        app: neuvector-prometheus-exporter
         release: {{ .Release.Name }}
     spec:
     {{- if .Values.imagePullSecrets }}
@@ -33,7 +33,7 @@ spec:
       serviceAccount: basic
     {{- end }}
       containers:
-        - name: neuvector-prometheus-exporter-pod
+        - name: neuvector-prometheus-exporter
           {{ if eq .Values.registry "registry.neuvector.com" }}
           {{ if .Values.oem }}
           image: "{{ .Values.registry }}/{{ .Values.oem }}/prometheus-exporter:{{ .Values.exporter.image.tag }}"

--- a/charts/monitor/templates/exporter-service.yaml
+++ b/charts/monitor/templates/exporter-service.yaml
@@ -24,5 +24,5 @@ spec:
       targetPort: 8068
       protocol: TCP
   selector:
-    app: neuvector-prometheus-exporter-pod
+    app: neuvector-prometheus-exporter
 {{- end }}

--- a/charts/monitor/templates/secret.yaml
+++ b/charts/monitor/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-prometheus-exporter-pod-secret
+  name: neuvector-prometheus-exporter-pod
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/monitor/templates/secret.yaml
+++ b/charts/monitor/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-prometheus-exporter
+  name: neuvector-prometheus-exporter-pod
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/monitor/templates/secret.yaml
+++ b/charts/monitor/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-prometheus-exporter-pod
+  name: neuvector-prometheus-exporter
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/monitor/templates/secret.yaml
+++ b/charts/monitor/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-prometheus-exporter-secret
+  name: neuvector-prometheus-exporter
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/monitor/templates/secret.yaml
+++ b/charts/monitor/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-prometheus-exporter-pod
+  name: neuvector-prometheus-exporter-pod-secret
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/monitor/templates/secret.yaml
+++ b/charts/monitor/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: neuvector-prometheus-exporter-pod-secret
+  name: neuvector-prometheus-exporter-secret
   namespace: {{ .Release.Namespace }}
   labels:
     chart: {{ template "neuvector.chart" . }}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -16,7 +16,7 @@ exporter:
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin
 
-  apiSvc: neuvector-svc-controller-api:10443
+  apiSvc: neuvector-controller-api:10443
 
   svc:
     enabled: true

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -353,7 +353,7 @@ func TestControllerSecrets(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl-secret",
+						SecretName: "nv-ssl",
 					},
 				},
 			})
@@ -424,7 +424,7 @@ func TestControllerNoSecrets(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl-secret",
+						SecretName: "nv-ssl",
 					},
 				},
 			})
@@ -458,7 +458,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"controller.certificate.secret":  "nv-ssl-secret",
+			"controller.certificate.secret":  "nv-ssl",
 			"controller.certificate.keyFile": "key3.pem",
 			"controller.certificate.pemFile": "cert3.pem",
 		},
@@ -490,7 +490,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl-secret",
+						SecretName: "nv-ssl",
 					},
 				},
 			})

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -304,7 +304,7 @@ func TestControllerSecrets(t *testing.T) {
 	for _, output := range outs {
 		var secret corev1.Secret
 		helm.UnmarshalK8SYaml(t, output, &secret)
-		if secret.Name == "neuvector-controller-secret" {
+		if secret.Name == "neuvector-controller" {
 			assert.NotNil(t, secret.Data)
 			assert.NotEmpty(t, secret.Data["ssl-cert.key"])
 			assert.NotEmpty(t, secret.Data["ssl-cert.pem"])
@@ -327,7 +327,7 @@ func TestControllerSecrets(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller-secret",
+						SecretName: "neuvector-controller",
 					},
 				},
 			})
@@ -344,7 +344,7 @@ func TestControllerSecrets(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller-secret",
+						SecretName: "neuvector-controller",
 					},
 				},
 			})
@@ -353,7 +353,7 @@ func TestControllerSecrets(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl-secret",
+						SecretName: "nv-ssl",
 					},
 				},
 			})
@@ -402,7 +402,7 @@ func TestControllerNoSecrets(t *testing.T) {
 	for _, output := range outs {
 		var secret corev1.Secret
 		helm.UnmarshalK8SYaml(t, output, &secret)
-		assert.NotEqual(t, "neuvector-controller-secret", secret.Name)
+		assert.NotEqual(t, "neuvector-controller", secret.Name)
 	}
 
 	for _, output := range outs {
@@ -415,7 +415,7 @@ func TestControllerNoSecrets(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller-secret",
+						SecretName: "neuvector-controller",
 					},
 				},
 			})
@@ -424,7 +424,7 @@ func TestControllerNoSecrets(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl-secret",
+						SecretName: "nv-ssl",
 					},
 				},
 			})
@@ -458,7 +458,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"controller.certificate.secret":  "nv-ssl-secret",
+			"controller.certificate.secret":  "nv-ssl",
 			"controller.certificate.keyFile": "key3.pem",
 			"controller.certificate.pemFile": "cert3.pem",
 		},
@@ -481,7 +481,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller-secret",
+						SecretName: "neuvector-controller",
 					},
 				},
 			})
@@ -490,7 +490,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl-secret",
+						SecretName: "nv-ssl",
 					},
 				},
 			})

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -123,7 +123,7 @@ func TestControllerDeploymentDisrupt(t *testing.T) {
 // --
 
 func checkManagerDeployment(t *testing.T, dep appsv1.Deployment, ssl bool) {
-	if dep.Name != "neuvector-manager-pod" {
+	if dep.Name != "neuvector-manager" {
 		t.Errorf("Deployment name is wrong. name=%v\n", dep.Name)
 	}
 
@@ -321,7 +321,7 @@ func TestControllerSecrets(t *testing.T) {
 	for _, output := range outs {
 		var dep appsv1.Deployment
 		helm.UnmarshalK8SYaml(t, output, &dep)
-		if dep.Name == "neuvector-controller-pod" {
+		if dep.Name == "neuvector-controller" {
 
 			assert.Contains(t, dep.Spec.Template.Spec.Volumes, corev1.Volume{
 				Name: "cert",
@@ -337,7 +337,7 @@ func TestControllerSecrets(t *testing.T) {
 	for _, output := range outs {
 		var dep appsv1.Deployment
 		helm.UnmarshalK8SYaml(t, output, &dep)
-		if dep.Name == "neuvector-controller-pod" {
+		if dep.Name == "neuvector-controller" {
 
 			// cert and usercert will be mounted.
 			assert.Contains(t, dep.Spec.Template.Spec.Volumes, corev1.Volume{
@@ -359,7 +359,7 @@ func TestControllerSecrets(t *testing.T) {
 			})
 
 			for _, container := range dep.Spec.Template.Spec.Containers {
-				if container.Name == "neuvector-controller-pod" {
+				if container.Name == "neuvector-controller" {
 
 					assert.Contains(t, container.VolumeMounts, corev1.VolumeMount{
 						Name:      "cert",
@@ -408,7 +408,7 @@ func TestControllerNoSecrets(t *testing.T) {
 	for _, output := range outs {
 		var dep appsv1.Deployment
 		helm.UnmarshalK8SYaml(t, output, &dep)
-		if dep.Name == "neuvector-controller-pod" {
+		if dep.Name == "neuvector-controller" {
 
 			// cert and usercert will be mounted.
 			assert.NotContains(t, dep.Spec.Template.Spec.Volumes, corev1.Volume{
@@ -430,7 +430,7 @@ func TestControllerNoSecrets(t *testing.T) {
 			})
 
 			for _, container := range dep.Spec.Template.Spec.Containers {
-				if container.Name == "neuvector-controller-pod" {
+				if container.Name == "neuvector-controller" {
 
 					assert.NotContains(t, container.VolumeMounts, corev1.VolumeMount{
 						Name:      "cert",
@@ -474,7 +474,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 	for _, output := range outs {
 		var dep appsv1.Deployment
 		helm.UnmarshalK8SYaml(t, output, &dep)
-		if dep.Name == "neuvector-controller-pod" {
+		if dep.Name == "neuvector-controller" {
 
 			// cert and usercert will be mounted.
 			assert.Contains(t, dep.Spec.Template.Spec.Volumes, corev1.Volume{
@@ -496,7 +496,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 			})
 
 			for _, container := range dep.Spec.Template.Spec.Containers {
-				if container.Name == "neuvector-controller-pod" {
+				if container.Name == "neuvector-controller" {
 
 					assert.Contains(t, container.VolumeMounts, corev1.VolumeMount{
 						Name:      "usercert",

--- a/test/deployment_test.go
+++ b/test/deployment_test.go
@@ -304,7 +304,7 @@ func TestControllerSecrets(t *testing.T) {
 	for _, output := range outs {
 		var secret corev1.Secret
 		helm.UnmarshalK8SYaml(t, output, &secret)
-		if secret.Name == "neuvector-controller" {
+		if secret.Name == "neuvector-controller-secret" {
 			assert.NotNil(t, secret.Data)
 			assert.NotEmpty(t, secret.Data["ssl-cert.key"])
 			assert.NotEmpty(t, secret.Data["ssl-cert.pem"])
@@ -327,7 +327,7 @@ func TestControllerSecrets(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller",
+						SecretName: "neuvector-controller-secret",
 					},
 				},
 			})
@@ -344,7 +344,7 @@ func TestControllerSecrets(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller",
+						SecretName: "neuvector-controller-secret",
 					},
 				},
 			})
@@ -353,7 +353,7 @@ func TestControllerSecrets(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl",
+						SecretName: "nv-ssl-secret",
 					},
 				},
 			})
@@ -402,7 +402,7 @@ func TestControllerNoSecrets(t *testing.T) {
 	for _, output := range outs {
 		var secret corev1.Secret
 		helm.UnmarshalK8SYaml(t, output, &secret)
-		assert.NotEqual(t, "neuvector-controller", secret.Name)
+		assert.NotEqual(t, "neuvector-controller-secret", secret.Name)
 	}
 
 	for _, output := range outs {
@@ -415,7 +415,7 @@ func TestControllerNoSecrets(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller",
+						SecretName: "neuvector-controller-secret",
 					},
 				},
 			})
@@ -424,7 +424,7 @@ func TestControllerNoSecrets(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl",
+						SecretName: "nv-ssl-secret",
 					},
 				},
 			})
@@ -458,7 +458,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"controller.certificate.secret":  "nv-ssl",
+			"controller.certificate.secret":  "nv-ssl-secret",
 			"controller.certificate.keyFile": "key3.pem",
 			"controller.certificate.pemFile": "cert3.pem",
 		},
@@ -481,7 +481,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 				Name: "cert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "neuvector-controller",
+						SecretName: "neuvector-controller-secret",
 					},
 				},
 			})
@@ -490,7 +490,7 @@ func TestControllerWithOnlySSLKeys(t *testing.T) {
 				Name: "usercert",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "nv-ssl",
+						SecretName: "nv-ssl-secret",
 					},
 				},
 			})

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -17,7 +17,7 @@ func checkControllerServiceDefault(t *testing.T, svc corev1.Service) {
 	if len(svc.Spec.Ports) != 3 {
 		t.Errorf("Service port is wrong. ports=%+v\n", svc.Spec.Ports)
 	}
-	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller-pod" {
+	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller" {
 		t.Errorf("Service selector is invalid. selector=%+v\n", svc.Spec.Selector)
 	}
 }
@@ -32,7 +32,7 @@ func checkControllerServiceAPI(t *testing.T, svc corev1.Service, svcType string)
 	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 10443 {
 		t.Errorf("Service port is wrong. ports=%+v\n", svc.Spec.Ports)
 	}
-	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller-pod" {
+	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller" {
 		t.Errorf("Service selector is invalid. selector=%+v\n", svc.Spec.Selector)
 	}
 }
@@ -47,7 +47,7 @@ func checkControllerServiceFedMaster(t *testing.T, svc corev1.Service, svcType s
 	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 11443 {
 		t.Errorf("Service port is wrong. ports=%+v\n", svc.Spec.Ports)
 	}
-	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller-pod" {
+	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller" {
 		t.Errorf("Service selector is invalid. selector=%+v\n", svc.Spec.Selector)
 	}
 }
@@ -62,7 +62,7 @@ func checkControllerServiceFedManaged(t *testing.T, svc corev1.Service, svcType 
 	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 10443 {
 		t.Errorf("Service port is wrong. ports=%+v\n", svc.Spec.Ports)
 	}
-	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller-pod" {
+	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-controller" {
 		t.Errorf("Service selector is invalid. selector=%+v\n", svc.Spec.Selector)
 	}
 }
@@ -249,7 +249,7 @@ func checkManagerService(t *testing.T, svc corev1.Service, svcType string) {
 	if len(svc.Spec.Ports) != 1 || svc.Spec.Ports[0].Port != 8443 {
 		t.Errorf("Service port is wrong. ports=%+v\n", svc.Spec.Ports)
 	}
-	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-manager-pod" {
+	if app, ok := svc.Spec.Selector["app"]; !ok || app != "neuvector-manager" {
 		t.Errorf("Service selector is invalid. selector=%+v\n", svc.Spec.Selector)
 	}
 }

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func checkControllerServiceDefault(t *testing.T, svc corev1.Service) {
-	if svc.Name != "neuvector-svc-controller" {
+	if svc.Name != "neuvector-controller" {
 		t.Errorf("Service name is wrong. name=%v\n", svc.Name)
 	}
 	if svc.Spec.Type != "" || svc.Spec.ClusterIP != "None" {
@@ -23,7 +23,7 @@ func checkControllerServiceDefault(t *testing.T, svc corev1.Service) {
 }
 
 func checkControllerServiceAPI(t *testing.T, svc corev1.Service, svcType string) {
-	if svc.Name != "neuvector-svc-controller-api" {
+	if svc.Name != "neuvector-controller-api" {
 		t.Errorf("Service name is wrong. name=%v\n", svc.Name)
 	}
 	if string(svc.Spec.Type) != svcType {
@@ -38,7 +38,7 @@ func checkControllerServiceAPI(t *testing.T, svc corev1.Service, svcType string)
 }
 
 func checkControllerServiceFedMaster(t *testing.T, svc corev1.Service, svcType string) {
-	if svc.Name != "neuvector-svc-controller-fed-master" {
+	if svc.Name != "neuvector-controller-fed-master" {
 		t.Errorf("Service name is wrong. name=%v\n", svc.Name)
 	}
 	if string(svc.Spec.Type) != svcType {
@@ -53,7 +53,7 @@ func checkControllerServiceFedMaster(t *testing.T, svc corev1.Service, svcType s
 }
 
 func checkControllerServiceFedManaged(t *testing.T, svc corev1.Service, svcType string) {
-	if svc.Name != "neuvector-svc-controller-fed-managed" {
+	if svc.Name != "neuvector-controller-fed-managed" {
 		t.Errorf("Service name is wrong. name=%v\n", svc.Name)
 	}
 	if string(svc.Spec.Type) != svcType {

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -240,7 +240,7 @@ func TestControllerServiceIngress(t *testing.T) {
 // -- manager
 
 func checkManagerService(t *testing.T, svc corev1.Service, svcType string) {
-	if svc.Name != "neuvector-service-webui" {
+	if svc.Name != "neuvector-webui" {
 		t.Errorf("Service name is wrong. name=%v\n", svc.Name)
 	}
 	if string(svc.Spec.Type) != svcType {

--- a/test/updater_test.go
+++ b/test/updater_test.go
@@ -31,7 +31,7 @@ func TestUpdater(t *testing.T) {
 
 		switch i {
 		case 0:
-			if job.Name != "neuvector-updater-pod" {
+			if job.Name != "neuvector-updater" {
 				t.Errorf("Incorrect cronjob name. name=%v\n", job.Name)
 			}
 			if job.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Lifecycle != nil {
@@ -65,7 +65,7 @@ func TestUpdaterWithScanner(t *testing.T) {
 
 		switch i {
 		case 0:
-			if job.Name != "neuvector-updater-pod" {
+			if job.Name != "neuvector-updater" {
 				t.Errorf("Incorrect cronjob name. name=%v\n", job.Name)
 			}
 		}


### PR DESCRIPTION
The Kubernetes objects created by this Helm chart were littered with the "-pod" suffix for resource names and labels. Notably, this was the case for non-pod resources. This change removes that suffix.

I also noticed that the secrets had a `-secrets` suffix, and services had sometimes `-svc` and sometimes `-service` infixes which are also removed with in change. It is always clear from the manifest what resource kind one is working with; so I see no need to over-specify this into the `.metadata.name` field as well.

Fixes #327 