### PR TITLE
allow to use pre-existing secret for controller user

### DIFF
--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -51,6 +51,10 @@ spec:
               value: "8068"
           envFrom:
             - secretRef:
+            {{- if .Values.exporter.ctrlSercretName }}
+                name: {{ .Values.exporter.ctrlSercretName }}
+            {{ else }}
                 name: neuvector-prometheus-exporter-pod-secret
+            {{- end }}
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/secret.yaml
+++ b/charts/monitor/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.exporter.enabled -}}
+{{- if and (.Values.exporter.enabled) (not .Values.exporter.ctrlSercretName)  -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -15,6 +15,7 @@ exporter:
   # changes this to a readonly user !
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin
+  ctrlSercretName: nv-exporter-secret
 
   apiSvc: neuvector-svc-controller-api:10443
 


### PR DESCRIPTION
Allow user to use an existing secret for CTRL_USERNAME and CTRL_PASSWORD. This is useful if the user already using externalsecret or externally managed secret.