### PR TITLE
add helm parameter to enable 'ENFORCER_STATS' env variable

### DIFF
--- a/charts/monitor/README.md
+++ b/charts/monitor/README.md
@@ -17,7 +17,7 @@ Parameter | Description | Default | Notes
 `exporter.ctrlSercretName` | existing secret that have CTRL_USERNAME and CTRL_PASSWORD fields to login to the controller.  | `nil` | if parameter exists then `exporter.CTRL_USERNAME` & `exporter.CTRL_PASSWORD` will be skipped
 `exporter.CTRL_USERNAME` | Username to login to the controller. Suggest to replace the default admin user to a read-only user | `admin` |
 `exporter.CTRL_PASSWORD` | Password to login to the controller. | `admin` |
-
+`exporter.enforcerStats.enabled` | If true, enable the Enforcers stats | `false` | For the performance reason, by default the exporter does NOT pull CPU/memory usage from enforcers.
 ---
 Contact <support@neuvector.com> for access to Docker Hub and docs.
 

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -49,6 +49,10 @@ spec:
               value: {{ .Values.exporter.apiSvc }}
             - name: EXPORTER_PORT
               value: "8068"
+            {{- if .Values.exporter.enforcerStats }}
+            - name: ENFORCER_STATS
+              value: "{{.Values.exporter.enforcerStats.enabled | default "false"}}"
+            {{- end }}
           envFrom:
             - secretRef:
             {{- if .Values.exporter.ctrlSercretName }}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -16,7 +16,8 @@ exporter:
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin
   ctrlSercretName: ''
-
+  enforcerStats:
+    enabled: false
   apiSvc: neuvector-svc-controller-api:10443
 
   svc:


### PR DESCRIPTION
Currently the helm template is not defining `ENFORCER_STATS` Environment Variable
https://github.com/neuvector/prometheus-exporter/blob/master/README.md?plain=1#L45

Users want to have the option to enable the enforcers stats through helm params 