### PR TITLE
Switch to using images tags instead of digests for azure

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -80,7 +80,7 @@ spec:
       containers:
         - name: neuvector-controller-pod
           {{- if .Values.global.azure.enabled }}
-          image: "{{ .Values.global.azure.images.controller.registry }}/{{ .Values.global.azure.images.controller.image }}@{{ .Values.global.azure.images.controller.digest }}"
+          image: "{{ .Values.global.azure.images.controller.registry }}/{{ .Values.global.azure.images.controller.image }}:{{ .Values.global.azure.images.controller.tag }}"
           {{- else }}
           {{- if eq .Values.registry "registry.neuvector.com" }}
           {{- if .Values.oem }}

--- a/charts/core/templates/csp-deployment.yaml
+++ b/charts/core/templates/csp-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         {{- else if and .Values.global.aws.enabled .Values.global.aws.image.tag }}
         image: "{{ .Values.registry }}/{{ .Values.global.aws.image.repository }}:{{ .Values.global.aws.image.tag }}"
         {{- else if and .Values.global.azure.enabled }}
-        image: "{{ .Values.global.azure.images.neuvector_csp_pod.registry }}/{{ .Values.global.azure.images.neuvector_csp_pod.image }}@{{ .Values.global.azure.images.neuvector_csp_pod.digest }}"
+        image: "{{ .Values.global.azure.images.neuvector_csp_pod.registry }}/{{ .Values.global.azure.images.neuvector_csp_pod.image }}:{{ .Values.global.azure.images.neuvector_csp_pod.tag }}"
         {{- end }}
         name: neuvector-csp-pod
         {{- if .Values.global.aws.enabled }}

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -68,7 +68,7 @@ spec:
       containers:
         - name: neuvector-manager-pod
           {{- if .Values.global.azure.enabled }}
-          image: "{{ .Values.global.azure.images.manager.registry }}/{{ .Values.global.azure.images.manager.image }}@{{ .Values.global.azure.images.manager.digest }}"
+          image: "{{ .Values.global.azure.images.manager.registry }}/{{ .Values.global.azure.images.manager.image }}:{{ .Values.global.azure.images.manager.tag }}"
           {{- else }}
           {{- if eq .Values.registry "registry.neuvector.com" }}
           {{- if .Values.oem }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -27,26 +27,22 @@ global: # required for rancher authentication (https://<Rancher_URL>/)
     imagePullSecrets:
     images:
       neuvector_csp_pod:
-        digest: 
+        tag: latest
         image: neuvector-billing-azure-by-suse-llc
-        registry: susellcforazuremarketplace.azurecr.io
+        registry: registry.suse.de/suse/sle-15-sp5/update/pubclouds/images
         imagePullPolicy: IfNotPresent
       controller:
-        digest: ""
-        image: neuvector/controller
-        registry: docker.io
+        tag: 5.2.4
+        image: controller
+        registry: docker.io/neuvector
       manager:
-        digest: ""
-        image: neuvector/manager
-        registry: docker.io
-      scanner:
-        digest: ""
-        image: neuvector/scanner
-        registry: docker.io
+        tag: 5.2.4
+        image: manager
+        registry: docker.io/neuvector
       enforcer:
-        digest: ""
-        image: neuvector/enforcer
-        registry: docker.io
+        tag: 5.2.4
+        image: enforcer
+        registry: docker.io/neuvector
 
   aws:
     enabled: false


### PR DESCRIPTION
The tool that Microsoft uses to create the CNAB bundle for the Azure Marketplace offer has been enhanced to support image tags as well as digests.

https://github.com/Azure-Samples/kubernetes-offer-samples/pull/31

This PR switchws the azure image handling to tags to be consistent with the other platforms.

Additionally, since the scanner is not installed as part of the Azure Marketplace offer, but added after,  it was removed from the Azure section.  

https://suse-enceladus.github.io/marketplace-docs/neuvector-prime/azure/