### PR TITLE
Add probes on manager

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -169,6 +169,9 @@ Parameter | Description | Default | Notes
 `manager.tolerations` | List of node taints to tolerate | `nil` |
 `manager.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
 `manager.runAsUser` | Specify the run as User ID | `nil` |
+`manager.probes.timeout` | timeout for startup, liveness and readiness probes | 1 |
+`manager.probes.periodSeconds` | periodSeconds for startup, liveness and readiness probes | 10 |
+`manager.probes.startupFailureThreshold` | failure thresold for startup probe | 30 |
 `cve.adapter.enabled` | If true, create registry adapter | `true` |
 `cve.adapter.image.repository` | registry adapter image repository | `neuvector/registry-adapter` |
 `cve.adapter.image.tag` | registry adapter image tag | |

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -169,6 +169,7 @@ Parameter | Description | Default | Notes
 `manager.tolerations` | List of node taints to tolerate | `nil` |
 `manager.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
 `manager.runAsUser` | Specify the run as User ID | `nil` |
+`manager.probes.enabled` | enabled startup, liveness and readiness probes | 1 |
 `manager.probes.timeout` | timeout for startup, liveness and readiness probes | 1 |
 `manager.probes.periodSeconds` | periodSeconds for startup, liveness and readiness probes | 10 |
 `manager.probes.startupFailureThreshold` | failure threshold for startup probe | 30 |

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -171,7 +171,7 @@ Parameter | Description | Default | Notes
 `manager.runAsUser` | Specify the run as User ID | `nil` |
 `manager.probes.timeout` | timeout for startup, liveness and readiness probes | 1 |
 `manager.probes.periodSeconds` | periodSeconds for startup, liveness and readiness probes | 10 |
-`manager.probes.startupFailureThreshold` | failure thresold for startup probe | 30 |
+`manager.probes.startupFailureThreshold` | failure threshold for startup probe | 30 |
 `cve.adapter.enabled` | If true, create registry adapter | `true` |
 `cve.adapter.image.repository` | registry adapter image repository | `neuvector/registry-adapter` |
 `cve.adapter.image.tag` | registry adapter image tag | |

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -113,6 +113,8 @@ spec:
               subPath: ssl-cert.pem
               name: cert
               readOnly: true
+          {{- end }}
+          {{- if .Values.manager.probes.enabled }}
           startupProbe:
             httpGet:
               path: /

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -119,6 +119,11 @@ spec:
             httpGet:
               path: /
               port: 8443
+              {{- if .Values.manager.env.ssl }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
             timeoutSeconds: {{ .Values.manager.probes.timeout | default 1 }}
             periodSeconds: {{ .Values.manager.probes.periodSeconds | default 10 }}
             successThreshold: 1
@@ -127,6 +132,11 @@ spec:
             httpGet:
               path: /
               port: 8443
+              {{- if .Values.manager.env.ssl }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
             timeoutSeconds: {{ .Values.manager.probes.timeout | default 1 }}
             periodSeconds: {{ .Values.manager.probes.periodSeconds | default 10 }}
             successThreshold: 1
@@ -135,6 +145,11 @@ spec:
             httpGet:
               path: /
               port: 8443
+              {{- if .Values.manager.env.ssl }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
             timeoutSeconds: {{ .Values.manager.probes.timeout | default 1 }}
             periodSeconds: {{ .Values.manager.probes.periodSeconds | default 10 }}
             successThreshold: 1

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -113,6 +113,30 @@ spec:
               subPath: ssl-cert.pem
               name: cert
               readOnly: true
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8443
+            timeoutSeconds: {{ .Values.manager.probes.timeout | default 1 }}
+            periodSeconds: {{ .Values.manager.probes.periodSeconds | default 10 }}
+            successThreshold: 1
+            failureThreshold: {{ .Values.manager.probes.startupFailureThreshold | default 30 }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8443
+            timeoutSeconds: {{ .Values.manager.probes.timeout | default 1 }}
+            periodSeconds: {{ .Values.manager.probes.periodSeconds | default 10 }}
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8443
+            timeoutSeconds: {{ .Values.manager.probes.timeout | default 1 }}
+            periodSeconds: {{ .Values.manager.probes.periodSeconds | default 10 }}
+            successThreshold: 1
+            failureThreshold: 3
           {{- end }}
           resources:
           {{- if .Values.manager.resources }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -386,6 +386,7 @@ manager:
     # key2: value2
   runAsUser: # MUST be set for Rancher hardened cluster
   probes:
+    enabled: false
     timeout: 1
     periodSeconds: 10
     startupFailureThreshold: 30

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -385,6 +385,10 @@ manager:
     # key1: value1
     # key2: value2
   runAsUser: # MUST be set for Rancher hardened cluster
+  probes:
+    timeout: 1
+    periodSeconds: 10
+    startupFailureThreshold: 30
 
 cve:
   adapter:


### PR DESCRIPTION
When the manager is redeployed, it take a long time before it can take traffic. 
The new manager container is marked ready (because no readiness is configured) but it can't forward requests correctly and the interface became unstable.

This PR add probes on manager : 

- readiness / liveness
- startupProbe on case witch app is slow to startup.