### PR TITLE
Fix expose port to be accessed by neuvector-service-webui

### DIFF
--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -84,6 +84,10 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+          ports:
+            - name: http
+              containerPort: 8443
+              protocol: TCP
           env:
             - name: CTRL_SERVER_IP
               value: neuvector-svc-controller.{{ .Release.Namespace }}


### PR DESCRIPTION
The port section is missing in manager-deployment.yaml, in order to access the pod web ui, we need to have this port exposed so the service neuvector-service-webui can access to the application.

For now i have to add it manually after neuvector helm deployment.