### PR TITLE
feat: add support for monitor chart securityContext and labels

### DIFF
--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -23,6 +23,9 @@ spec:
       labels:
         app: neuvector-prometheus-exporter-pod
         release: {{ .Release.Name }}
+      {{- with .Values.exporter.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -32,6 +35,10 @@ spec:
       serviceAccountName: basic
       serviceAccount: basic
     {{- end }}
+      {{- with .Values.exporter.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: neuvector-prometheus-exporter-pod
           {{ if eq .Values.registry "registry.neuvector.com" }}
@@ -44,6 +51,10 @@ spec:
           image: "{{ .Values.registry }}/{{ .Values.exporter.image.repository }}:{{ .Values.exporter.image.tag }}"
           {{- end }}
           imagePullPolicy: Always
+          {{- with .Values.exporter.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: CTRL_API_SERVICE
               value: {{ .Values.exporter.apiSvc }}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -20,6 +20,8 @@ exporter:
     enabled: false
   ctrlSecretName: ''
   apiSvc: neuvector-svc-controller-api:10443
+  securityContext: {}
+  containerSecurityContext: {}
 
   svc:
     enabled: true

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -20,6 +20,7 @@ exporter:
     enabled: false
   ctrlSecretName: ''
   apiSvc: neuvector-svc-controller-api:10443
+  podLabels: {}
   securityContext: {}
   containerSecurityContext: {}
 


### PR DESCRIPTION
Certain environments may use different images for the exporter which require a different run as user/group (i.e. a hardened image which is based on a different base image). There are also environments where certain security contexts may be enforced (i.e. no running as root, all capabilities must be dropped, etc). In these cases it is beneficial to expose the securityContext (and containerSecurityContext).

It's also generally nice to expose pod labels.