### PR TITLE
Change certificate default value

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -197,7 +197,7 @@ Parameter | Description | Default | Notes
 `cve.adapter.route.tls.destinationCACertificate` | Set controller REST API service CA certificate to validate the endpoint certificate for OpenShift route for management console service | `nil` |
 `cve.adapter.certificate.secret` | Replace registry adapter certificate using secret if secret name is specified | `nil` |
 `cve.adapter.certificate.keyFile` | Replace registry adapter certificate key file | `tls.key` |
-`cve.adapter.certificate.pemFile` | Replace registry adapter certificate pem file | `tls.pem` |
+`cve.adapter.certificate.pemFile` | Replace registry adapter certificate crt file | `tls.crt` |
 `cve.adapter.ingress.enabled` | If true, create ingress, must also set ingress host value | `false` | enable this if ingress controller is installed
 `cve.adapter.ingress.host` | Must set this host value if ingress is enabled | `nil` |
 `cve.adapter.ingress.ingressClassName` | To be used instead of the ingress.class annotation if an IngressClass is provisioned | `""` |

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -424,7 +424,7 @@ cve:
     certificate:
       secret:
       keyFile: tls.key
-      pemFile: tls.pem
+      pemFile: tls.crt
     harbor:
       protocol: https
       secretName:


### PR DESCRIPTION
The current default value in the core chart for `cve.adapter.certificate.pemFile=tls.pem`. Recommend switching to `cve.adapter.certificate.pemFile=tls.crt` as that conforms to a TLS Certificate Secret API: https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets

Trying to use the default with a TLS secret (i.e. generated from cert-manager) does not work and Kubernetes fails to mount the secret into the pod with:

```bash
RunContainerError (failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/lib/kubelet/pods/c835b473-2b37-4fb2-86f6-b3d86d56d4f1/volume-subpaths/cert/neuvector-registry-adapter-pod/1" to rootfs at "/etc/neuvector/certs/ssl-cert.pem": mount /var/lib/kubelet/pods/c835b473-2b37-4fb2-86f6-b3d86d56d4f1/volume-subpaths/cert/neuvector-registry-adapter-pod/1:/etc/neuvector/certs/ssl-cert.pem (via /proc/self/fd/6), flags: 0x5001, data: context="system_u:object_r:container_file_t:s0:c39,c227": not a directory: unknown) | Last state: Terminated with 128: StartError (failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting &quot;/var/lib/kubelet/pods/c835b473-2b37-4fb2-86f6-b3d86d56d4f1/volume-subpaths/cert/neuvector-registry-adapter-pod/1&quot; to rootfs at &quot;/etc/neuvector/certs/ssl-cert.pem&quot;: mount /var/lib/kubelet/pods/c835b473-2b37-4fb2-86f6-b3d86d56d4f1/volume-subpaths/cert/neuvector-registry-adapter-pod/1:/etc/neuvector/certs/ssl-cert.pem (via /proc/self/fd/6), flags: 0x5001, data: context=&quot;system_u:object_r:container_file_t:s0:c39,c227&quot;: not a directory: unknown), started: Wed, Dec 31 1969 6:00:00 pm, finished: Tue, Jan 30 2024 5:01:27 pm
```
