### PR TITLE
NVSHAS-8702: support autoGenerateCert as string

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- with .Values.controller.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.controller.secret.enabled .Values.controller.configmap.enabled .Values.controller.podAnnotations .Values.autoGenerateCert }}
+      {{- if or .Values.controller.secret.enabled .Values.controller.configmap.enabled .Values.controller.podAnnotations (eq "true" (toString .Values.autoGenerateCert)) }}
       annotations:
         {{- if .Values.controller.secret.enabled }}
         checksum/init-secret: {{ include (print $.Template.BasePath "/init-secret.yaml") . | sha256sum }}
@@ -44,7 +44,7 @@ spec:
         {{- if .Values.controller.configmap.enabled }}
         checksum/init-configmap: {{ include (print $.Template.BasePath "/init-configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.autoGenerateCert }}
+        {{- if eq "true" (toString .Values.autoGenerateCert) }}
         checksum/controller-secret: {{ include (print $.Template.BasePath "/controller-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.controller.podAnnotations }}
@@ -195,7 +195,7 @@ spec:
               subPath: {{ .Values.controller.certificate.pemFile }}
               name: usercert
               readOnly: true
-          {{- else if .Values.autoGenerateCert }}
+          {{- else if eq "true" (toString .Values.autoGenerateCert) }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: ssl-cert.key
               name: cert
@@ -268,7 +268,7 @@ spec:
               - secret:
                   name: neuvector-secret
                   optional: true
-      {{- if .Values.autoGenerateCert }}
+      {{- if eq "true" (toString .Values.autoGenerateCert) }}
         - name: cert
           secret:
             secretName: neuvector-controller-secret

--- a/charts/core/templates/controller-secret.yaml
+++ b/charts/core/templates/controller-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.controller.enabled -}}
-{{- if .Values.autoGenerateCert }}
+{{- if eq "true" (toString .Values.autoGenerateCert) }}
 {{- $cn := "neuvector" }}
 {{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
 apiVersion: v1

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -25,9 +25,9 @@ spec:
         {{- with .Values.manager.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.manager.podAnnotations .Values.autoGenerateCert }}
+      {{- if or .Values.manager.podAnnotations (eq "true" (toString .Values.autoGenerateCert)) }}
       annotations:
-        {{- if .Values.autoGenerateCert }}
+        {{- if eq "true" (toString .Values.autoGenerateCert) }}
         checksum/manager-secret: {{ include (print $.Template.BasePath "/manager-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.manager.podAnnotations }}
@@ -108,7 +108,7 @@ spec:
               subPath: {{ .Values.manager.certificate.pemFile }}
               name: cert
               readOnly: true
-          {{- else if .Values.autoGenerateCert }}
+          {{- else if eq "true" (toString .Values.autoGenerateCert) }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: ssl-cert.key
               name: cert
@@ -130,7 +130,7 @@ spec:
         - name: cert
           secret:
             secretName: {{ .Values.manager.certificate.secret }}
-      {{- else if .Values.autoGenerateCert }}
+      {{- else if eq "true" (toString .Values.autoGenerateCert) }}
         - name: cert
           secret:
             secretName: neuvector-manager-secret

--- a/charts/core/templates/manager-secret.yaml
+++ b/charts/core/templates/manager-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.manager.enabled -}}
-{{- if .Values.autoGenerateCert }}
+{{- if eq "true" (toString .Values.autoGenerateCert) }}
 {{- $cn := "neuvector" }}
 {{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
 apiVersion: v1

--- a/charts/core/templates/registry-adapter-secret.yaml
+++ b/charts/core/templates/registry-adapter-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.cve.adapter.enabled -}}
-{{- if .Values.autoGenerateCert }}
+{{- if eq "true" (toString .Values.autoGenerateCert) }}
 {{- $cn := "neuvector" }}
 {{- $cert := genSelfSignedCert $cn nil (list $cn "neuvector-service-registry-adapter.cattle-neuvector-system.svc.cluster.local" "neuvector-service-registry-adapter") (.Values.defaultValidityPeriod | int) -}}
 apiVersion: v1

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -25,9 +25,9 @@ spec:
         {{- with .Values.cve.adapter.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.cve.adapter.podAnnotations .Values.autoGenerateCert }}
+      {{- if or .Values.cve.adapter.podAnnotations (eq "true" (toString .Values.autoGenerateCert)) }}
       annotations:
-        {{- if .Values.autoGenerateCert }}
+        {{- if eq "true" (toString .Values.autoGenerateCert) }}
         checksum/registry-adapter-secret: {{ include (print $.Template.BasePath "/registry-adapter-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.cve.adapter.podAnnotations }}
@@ -110,7 +110,7 @@ spec:
               subPath: {{ .Values.cve.adapter.certificate.pemFile }}
               name: cert
               readOnly: true
-          {{- else if .Values.autoGenerateCert }}
+          {{- else if eq "true" (toString .Values.autoGenerateCert) }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: ssl-cert.key
               name: cert
@@ -147,7 +147,7 @@ spec:
         - name: cert
           secret:
             secretName: {{ .Values.cve.adapter.certificate.secret }}
-      {{- else if .Values.autoGenerateCert }}
+      {{- else if eq "true" (toString .Values.autoGenerateCert) }}
         - name: cert
           secret:
             secretName: neuvector-registry-adapter-secret


### PR DESCRIPTION
In 5.2.2, we temporarily enabled `autoGenerateCert` to generate TLS certificates.  While it was reverted in the following versions because of repeated reconciling from https://github.com/operator-framework/operator-sdk/issues/5728, the CR created by it will still persist.

To fix, it has to go through helm operator's [watch file's override values](https://sdk.operatorframework.io/docs/building-operators/helm/reference/advanced_features/override_values/).

However, operator-sdk has limitation to override boolean value per https://github.com/operator-framework/operator-sdk/issues/6115, hence this fix.

This commit allows string type of the flag, so we can override it from helm-operator level.

We can remove this temporary fix once https://github.com/operator-framework/operator-sdk/issues/5728 is supported.  