### PR TITLE
chore: add appProtocol to exporter svc

### DIFF
--- a/charts/monitor/templates/exporter-service.yaml
+++ b/charts/monitor/templates/exporter-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.exporter.enabled  .Values.exporter.svc.enabled -}}
+{{- if and .Values.exporter.enabled .Values.exporter.svc.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,6 +23,7 @@ spec:
       name: metrics
       targetPort: 8068
       protocol: TCP
+      appProtocol: http
   selector:
     app: neuvector-prometheus-exporter-pod
 {{- end }}


### PR DESCRIPTION
In attempting to use the exporter in an Istio mTLS STRICT environment I was encountering errors with Prometheus hitting the service properly. Narrowed this down to Istio's protocol selection and needing to explicit add this as HTTP traffic. Istio provides 2 ways to do this, [port name or appProtocol](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection). `appProtocol` was added here as it seems less disruptive/breaking.

Resolves https://github.com/neuvector/neuvector-helm/issues/390