### PR TITLE
Fixing internal certificate issue where secret name is null by default

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -143,7 +143,7 @@ controller:
     pemFile: tls.pem
   internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
     certificate:
-      secret: ""
+      secret: neuvector-internal
       keyFile: tls.key
       pemFile: tls.crt
       caFile: ca.crt # must be the same CA for all internal.
@@ -310,7 +310,7 @@ enforcer:
     #   memory: 2280Mi
   internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
     certificate:
-      secret: "" 
+      secret: neuvector-internal 
       keyFile: tls.key
       pemFile: tls.crt
       caFile: ca.crt # must be the same CA for all internal.
@@ -470,7 +470,7 @@ cve:
       secretName: # my-tls-secret
     internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
       certificate:
-        secret: "" 
+        secret: neuvector-internal
         keyFile: tls.key
         pemFile: tls.crt
         caFile: ca.crt # must be the same CA for all internal.
@@ -536,7 +536,7 @@ cve:
     runAsUser: # MUST be set for Rancher hardened cluster
     internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
       certificate:
-        secret: "" 
+        secret: neuvector-internal 
         keyFile: tls.key
         pemFile: tls.crt
         caFile: ca.crt # must be the same CA for all internal.


### PR DESCRIPTION
Fixing internal certificate issue where secret name is null by default. The current chart 2.7.6 defaults cause a null in a volume secret name. 

```
      volumes:
        - name: internal-cert
          secret:
            secretName:
```

Test with `helm template --debug neuvector --namespace cattle-neuvector-system neuvector/core --create-namespace --set internal.certmanager.enabled=true `

This PR fixes the defaults. This was working in the chart version 2.7.3.

Commit : https://github.com/neuvector/neuvector-helm/commit/6662ca9a8b2a92fd2d68e8e4ec5b0712da5ef67a
broke it.