### PR TITLE
bug: Remove duplicate volumeMounts keys from registry-adapter deployment

### DIFF
--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -119,15 +119,7 @@ spec:
               subPath: ssl-cert.pem
               name: cert
               readOnly: true
-          {{- end }}
-          resources:
-          {{- if .Values.cve.adapter.resources }}
-{{ toYaml .Values.cve.adapter.resources | indent 12 }}
-          {{- else }}
-{{ toYaml .Values.resources | indent 12 }}
-          {{- end }}
-          {{- if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
-          volumeMounts:
+          {{- else if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
             - mountPath: /etc/neuvector/certs/internal/cert.key
               subPath: {{ .Values.cve.adapter.internal.certificate.keyFile }}
               name: internal-cert
@@ -140,6 +132,12 @@ spec:
               subPath: {{ .Values.cve.adapter.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
+          {{- end }}
+          resources:
+          {{- if .Values.cve.adapter.resources }}
+{{ toYaml .Values.cve.adapter.resources | indent 12 }}
+          {{- else }}
+{{ toYaml .Values.resources | indent 12 }}
           {{- end }}
       restartPolicy: Always
       volumes:

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -101,7 +101,20 @@ spec:
 {{- toYaml . | nindent 14 }}
             {{- end }}
           volumeMounts:
-          {{- if .Values.cve.adapter.certificate.secret }}
+          {{- if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
+            - mountPath: /etc/neuvector/certs/internal/cert.key
+              subPath: {{ .Values.cve.adapter.internal.certificate.keyFile }}
+              name: internal-cert
+              readOnly: true
+            - mountPath: /etc/neuvector/certs/internal/cert.pem
+              subPath: {{ .Values.cve.adapter.internal.certificate.pemFile }}
+              name: internal-cert
+              readOnly: true
+            - mountPath: /etc/neuvector/certs/internal/ca.cert
+              subPath: {{ .Values.cve.adapter.internal.certificate.caFile }}
+              name: internal-cert
+              readOnly: true
+          {{- else if .Values.cve.adapter.certificate.secret }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: {{ .Values.cve.adapter.certificate.keyFile }}
               name: cert
@@ -118,19 +131,6 @@ spec:
             - mountPath: /etc/neuvector/certs/ssl-cert.pem
               subPath: ssl-cert.pem
               name: cert
-              readOnly: true
-          {{- else if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
-            - mountPath: /etc/neuvector/certs/internal/cert.key
-              subPath: {{ .Values.cve.adapter.internal.certificate.keyFile }}
-              name: internal-cert
-              readOnly: true
-            - mountPath: /etc/neuvector/certs/internal/cert.pem
-              subPath: {{ .Values.cve.adapter.internal.certificate.pemFile }}
-              name: internal-cert
-              readOnly: true
-            - mountPath: /etc/neuvector/certs/internal/ca.cert
-              subPath: {{ .Values.cve.adapter.internal.certificate.caFile }}
-              name: internal-cert
               readOnly: true
           {{- end }}
           resources:


### PR DESCRIPTION
This PR removes a duplicate `volumeMounts` key in the registry adapter deployment that appears when `.Values.internal.certmanager.enabled` is true or `.Values.cve.adapter.internal.certificate.secret` is defined.

To fix this, I combined the two `volumeMounts` sections. I moved the second `volumeMounts` values to the _top_ of the first `volumeMounts` section to ensure those mounts take precedence, as that is the behavior currently.

Resolves #398 