### PR TITLE
NVSHAS-7518 auto rotate internal certs

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -26,6 +26,8 @@ Parameter | Description | Default | Notes
 `autoGenerateCert` | Automatically generate certificate or not | `true` |
 `internal.certmanager.enabled` | cert-manager is installed for the internal certificates | `false` |
 `internal.certmanager.secretname` | Name of the secret to be used for the internal certificates | `neuvector-internal` |
+`internal.autoGenerateCert` | Automatically generate internal certificate or not | `true` |
+`internal.autoRotateCert` | Automatically rotate internal certificate or not | `false` |
 `defaultValidityPeriod` | The default validity period used for certs automatically generated (days) | `365` |
 `global.cattle.url` | Set the Rancher Server URL | | Required for Rancher Authentication. `https://<Rancher_URL>/` |
 `global.aws.enabled` | If true, install AWS billing csp adapter | `false` | **Note**: default admin user is disabled when aws market place billing enabled, use secret to create admin-role user to manage NeuVector deployment.
@@ -137,6 +139,13 @@ Parameter | Description | Default | Notes
 `controller.internal.certificate.keyFile` | Set PEM format key file for custom controller internal certificate | `tls.key` |
 `controller.internal.certificate.pemFile` | Set PEM format certificate file for custom controller internal certificate | `tls.crt` |
 `controller.internal.certificate.caFile` | Set CA certificate file for controller custom internal certificate | `ca.crt` |
+`controller.certupgrader.env` | User-defined environment variables. | `[]` |
+`controller.certupgrader.schedule` | cert upgrader schedule.  Leave empty to disable | `` |
+`controller.certupgrader.priorityClassName` | cert upgrader priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
+`controller.certupgrader.podLabels` | Specify the pod labels. | `{}` |
+`controller.certupgrader.podAnnotations` | Specify the pod annotations. | `{}` |
+`controller.certupgrader.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
+`controller.certupgrader.runAsUser` | Specify the run as User ID | `nil` |
 `enforcer.enabled` | If true, create enforcer | `true` |
 `enforcer.image.repository` | enforcer image repository | `neuvector/enforcer` |
 `enforcer.image.hash` | enforcer image hash in the format of sha256:xxxx. If present it overwrites the image tag value. | |

--- a/charts/core/templates/_helpers.tpl
+++ b/charts/core/templates/_helpers.tpl
@@ -46,3 +46,23 @@ Lookup secret.
 {{- printf "%s" $value -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "neuvector.controller.image" -}}
+{{- if .Values.global.azure.enabled }}
+  {{- printf "%s/%s:%s" .Values.global.azure.images.controller.registry .Values.global.azure.images.controller.image .Values.global.azure.images.controller.tag }}
+{{- else }}
+  {{- if eq .Values.registry "registry.neuvector.com" }}
+    {{- if .Values.oem }}
+      {{- printf "%s/%s/controller:%s" .Values.registry .Values.oem .Values.tag }}
+    {{- else }}
+      {{- printf "%s/controller:%s" .Values.registry .Values.tag }}
+    {{- end }}
+  {{- else }}
+    {{- if .Values.controller.image.hash }}
+      {{- printf "%s/%s@%s" .Values.registry .Values.controller.image.repository .Values.controller.image.hash }}
+    {{- else }}
+      {{- printf "%s/%s:%s" .Values.registry .Values.controller.image.repository .Values.tag }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -2,6 +2,10 @@
 {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" .Values.tag }}
 {{- $pre530 = (semverCompare "<5.2.10-0" .Values.tag) -}}
 {{- end }}
+{{- $pre540 := false -}}                                                
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" .Values.tag }}               
+{{- $pre540 = (semverCompare "<5.3.10-0" .Values.tag) -}}                  
+{{- end }}    
 {{- if .Values.controller.enabled -}}
 {{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: apps/v1
@@ -85,25 +89,27 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       serviceAccount: {{ .Values.serviceAccount }}
       {{- end }}
+      {{- if or .Values.internal.certmanager.enabled .Values.controller.internal.certificate.secret }}
+      {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
+      initContainers:
+        - name: init
+          image: {{ include "neuvector.controller.image" . | quote }}
+          command: ["/usr/local/bin/upgrader", "create-upgrader-job" ]
+          imagePullPolicy: {{ .Values.controller.certupgrader.imagePullPolicy }}
+          env:
+            - name: OVERRIDE_CHECKSUM
+              value: {{ dict "image" (include "neuvector.controller.image" .) "internal" .Values.internal "certupgrader" .Values.controller.certupgrader | toJson | sha256sum }}
+            {{- if and .Values.internal.autoRotateCert (not $pre540) }}
+            - name: ENABLE_ROTATION
+              value: "1"
+            {{- end }}
+          {{- with .Values.controller.certupgrader.env }}
+{{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: neuvector-controller-pod
-          {{- if .Values.global.azure.enabled }}
-          image: "{{ .Values.global.azure.images.controller.registry }}/{{ .Values.global.azure.images.controller.image }}:{{ .Values.global.azure.images.controller.tag }}"
-          {{- else }}
-          {{- if eq .Values.registry "registry.neuvector.com" }}
-          {{- if .Values.oem }}
-          image: "{{ .Values.registry }}/{{ .Values.oem }}/controller:{{ .Values.tag }}"
-          {{- else }}
-          image: "{{ .Values.registry }}/controller:{{ .Values.tag }}"
-          {{- end }}
-          {{- else }}
-          {{- if .Values.controller.image.hash }}
-          image: "{{ .Values.registry }}/{{ .Values.controller.image.repository }}@{{ .Values.controller.image.hash }}"
-          {{- else }}
-          image: "{{ .Values.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.tag }}"
-          {{- end }}
-          {{- end }}
-          {{- end }}
+          image: {{ include "neuvector.controller.image" . | quote }}
           {{- if $pre530 }}
           securityContext:
             privileged: true
@@ -155,6 +161,11 @@ spec:
           {{- end }}
           {{- if or .Values.global.aws.enabled .Values.global.azure.enabled }}
             - name: NO_DEFAULT_ADMIN
+              value: "1"
+          {{- end }}
+          {{- if or .Values.internal.certmanager.enabled .Values.controller.internal.certificate.secret }}
+          {{- else if .Values.internal.autoGenerateCert }}
+            - name: AUTO_INTERNAL_CERT
               value: "1"
           {{- end }}
           {{- with .Values.controller.env }}
@@ -223,6 +234,9 @@ spec:
               subPath: {{ .Values.controller.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
+          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+            - mountPath: /etc/neuvector/certs/internal/
+              name: internal-cert-dir
           {{- end }}
       terminationGracePeriodSeconds: 300
       restartPolicy: Always
@@ -286,6 +300,10 @@ spec:
         - name: internal-cert
           secret:
             secretName: {{ .Values.controller.internal.certificate.secret }}
+      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+        - name: internal-cert-dir
+          emptyDir:
+            sizeLimit: 50Mi
       {{- end }}
 {{- if gt (int .Values.controller.disruptionbudget) 0 }}
 ---

--- a/charts/core/templates/controller-lease.yaml
+++ b/charts/core/templates/controller-lease.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.internal.autoGenerateCert }}
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: neuvector-controller
+spec:
+  leaseTransitions: 0
+{{- end }}

--- a/charts/core/templates/controller-secret.yaml
+++ b/charts/core/templates/controller-secret.yaml
@@ -2,6 +2,7 @@
 {{- if eq "true" (toString .Values.autoGenerateCert) }}
 {{- $cn := "neuvector" }}
 {{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,6 +16,14 @@ type: Opaque
 data:
   ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}
   ssl-cert.pem: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-controller-secret" "key" "ssl-cert.pem" "defaultValue" $cert.Cert) }}
+{{- end}}
 ---
+{{- if .Values.internal.certmanager.enabled }}
+{{- else if .Values.internal.autoGenerateCert }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neuvector-internal-certs
+type: Opaque
 {{- end}}
 {{- end}}

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -2,6 +2,10 @@
 {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" .Values.tag }}
 {{- $pre530 = (semverCompare "<5.2.10-0" .Values.tag) -}}
 {{- end }}
+{{- $pre540 := false -}}                                                
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" .Values.tag }}               
+{{- $pre540 = (semverCompare "<5.3.10-0" .Values.tag) -}}                  
+{{- end }}    
 {{- $runtimePath := "" -}}
 {{- if .Values.runtimePath }}
 {{- $runtimePath = .Values.runtimePath -}}
@@ -105,6 +109,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+          {{- if or .Values.internal.certmanager.enabled .Values.enforcer.internal.certificate.secret }}
+          {{- else if .Values.internal.autoGenerateCert }}
+            - name: AUTO_INTERNAL_CERT
+              value: "1"
+          {{- end }}
           {{- with .Values.enforcer.env }}
 {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -153,6 +162,9 @@ spec:
               subPath: {{ .Values.enforcer.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
+          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+            - mountPath: /etc/neuvector/certs/internal/
+              name: internal-cert-dir
           {{- end }}
       terminationGracePeriodSeconds: 1200
       restartPolicy: Always
@@ -192,5 +204,9 @@ spec:
         - name: internal-cert
           secret:
             secretName: {{ .Values.enforcer.internal.certificate.secret }}
+      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+        - name: internal-cert-dir
+          emptyDir:
+            sizeLimit: 50Mi
       {{- end }}
 {{- end }}

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -1,3 +1,7 @@
+{{- $pre540 := false -}}                                                
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" .Values.tag }}               
+{{- $pre540 = (semverCompare "<5.3.10-0" .Values.tag) -}}                  
+{{- end }}    
 {{- if .Values.cve.adapter.enabled -}}
 {{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: apps/v1
@@ -97,6 +101,11 @@ spec:
                   name: {{ .Values.cve.adapter.harbor.secretName }}
                   key: password
             {{- end }}
+            {{- if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
+            {{- else if .Values.internal.autoGenerateCert }}
+            - name: AUTO_INTERNAL_CERT
+              value: "1"
+            {{- end }}
             {{- with .Values.cve.adapter.env }}
 {{- toYaml . | nindent 14 }}
             {{- end }}
@@ -126,8 +135,8 @@ spec:
           {{- else }}
 {{ toYaml .Values.resources | indent 12 }}
           {{- end }}
-          {{- if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
           volumeMounts:
+          {{- if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
             - mountPath: /etc/neuvector/certs/internal/cert.key
               subPath: {{ .Values.cve.adapter.internal.certificate.keyFile }}
               name: internal-cert
@@ -140,6 +149,9 @@ spec:
               subPath: {{ .Values.cve.adapter.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
+          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+            - mountPath: /etc/neuvector/certs/internal/
+              name: internal-cert-dir
           {{- end }}
       restartPolicy: Always
       volumes:
@@ -156,8 +168,11 @@ spec:
         - name: internal-cert
           secret:
             secretName: {{ .Values.cve.adapter.internal.certificate.secret }}
+      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+        - name: internal-cert-dir
+          emptyDir:
+            sizeLimit: 50Mi
       {{- end }}
-
 ---
 
 apiVersion: v1

--- a/charts/core/templates/role.yaml
+++ b/charts/core/templates/role.yaml
@@ -22,3 +22,114 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
+
+---
+
+{{- if .Values.internal.autoGenerateCert }}
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: Role
+metadata:
+  name: neuvector-binding-lease
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+---
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: Role
+metadata:
+  name: neuvector-binding-job-creation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/finalizers
+  verbs:
+  - update
+  - patch
+---
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: Role
+metadata:
+  name: neuvector-binding-cert-upgrader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - update
+{{- end }}

--- a/charts/core/templates/rolebinding-least.yaml
+++ b/charts/core/templates/rolebinding-least.yaml
@@ -35,8 +35,104 @@ userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:controller
 {{- end }}
 
+{{- if .Values.internal.autoGenerateCert }}
 ---
-
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: neuvector-binding-lease
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- end }}
+  name: neuvector-binding-lease
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: cert-upgrader
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount }}
+- system:serviceaccount:{{ .Release.Namespace }}:controller
+- system:serviceaccount:{{ .Release.Namespace }}:cert-upgrader
+{{- end }}
+---
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: neuvector-binding-job-creation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- end }}
+  name: neuvector-binding-job-creation
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:controller
+{{- end }}
+{{- end }}
+---
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: neuvector-binding-cert-upgrader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- end }}
+  name: neuvector-binding-cert-upgrader
+subjects:
+- kind: ServiceAccount
+  name: cert-upgrader
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:cert-upgrader
+{{- end }}
+---
 {{- if $oc3 }}
 apiVersion: authorization.openshift.io/v1
 {{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
@@ -62,9 +158,21 @@ subjects:
 - kind: ServiceAccount
   name: controller
   namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: enforcer
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: scanner
+  namespace: {{ .Release.Namespace }}
+- kind: ServiceAccount
+  name: registry-adapter
+  namespace: {{ .Release.Namespace }}
 {{- if $oc3 }}
 userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:controller
+- system:serviceaccount:{{ .Release.Namespace }}:enforcer
+- system:serviceaccount:{{ .Release.Namespace }}:scanner
+- system:serviceaccount:{{ .Release.Namespace }}:registry-adapter
 {{- end }}
 
 ---

--- a/charts/core/templates/rolebinding.yaml
+++ b/charts/core/templates/rolebinding.yaml
@@ -85,4 +85,95 @@ subjects:
   name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
+
+---
+
+{{- if .Values.internal.autoGenerateCert }}
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
 {{- end }}
+kind: RoleBinding
+metadata:
+  name: neuvector-binding-lease
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- end }}
+  name: neuvector-binding-lease
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+---
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: neuvector-binding-job-creation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- end }}
+  name: neuvector-binding-job-creation
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:controller
+{{- end }}
+---
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: RoleBinding
+metadata:
+  name: neuvector-binding-cert-upgrader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{{- end }}
+  name: neuvector-binding-cert-upgrader
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:cert-upgrader
+{{- end }}
+{{- end }}
+

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -1,3 +1,7 @@
+{{- $pre540 := false -}}                                                
+{{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" .Values.tag }}               
+{{- $pre540 = (semverCompare "<5.3.10-0" .Values.tag) -}}                  
+{{- end }}    
 {{- if .Values.cve.scanner.enabled -}}
 {{- if (semverCompare ">=1.9-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
 apiVersion: apps/v1
@@ -94,13 +98,18 @@ spec:
             - name: SCANNER_DOCKER_URL
               value: {{ .Values.cve.scanner.dockerPath }}
           {{- end }}
+          {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
+          {{- else if .Values.internal.autoGenerateCert }}
+            - name: AUTO_INTERNAL_CERT
+              value: "1"
+          {{- end }}
           {{- with .Values.cve.scanner.env }}
 {{- toYaml . | nindent 12 }}
           {{- end }}
           resources:
 {{ toYaml .Values.cve.scanner.resources | indent 12 }}
-          {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
           volumeMounts:
+          {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
             - mountPath: /etc/neuvector/certs/internal/cert.key
               subPath: {{ .Values.cve.scanner.internal.certificate.keyFile }}
               name: internal-cert
@@ -113,12 +122,19 @@ spec:
               subPath: {{ .Values.cve.scanner.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
+          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+            - mountPath: /etc/neuvector/certs/internal/
+              name: internal-cert-dir
           {{- end }}
       restartPolicy: Always
-      {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
       volumes:
+      {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
         - name: internal-cert
           secret:
             secretName: {{ .Values.cve.scanner.internal.certificate.secret }}
+      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+        - name: internal-cert-dir
+          emptyDir:
+            sizeLimit: 50Mi
       {{- end }}
 {{- end }}

--- a/charts/core/templates/serviceaccount-least.yaml
+++ b/charts/core/templates/serviceaccount-least.yaml
@@ -69,4 +69,15 @@ metadata:
     release: {{ .Release.Name }}
     heritage: Helm
 
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-upgrader
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
 {{- end }}

--- a/charts/core/templates/upgrader-cronjob.yaml
+++ b/charts/core/templates/upgrader-cronjob.yaml
@@ -1,0 +1,80 @@
+{{- if and .Values.controller.enabled .Values.internal.autoGenerateCert -}}
+{{- if (semverCompare ">=1.21-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: batch/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: batch/v1beta1
+{{- else }}
+apiVersion: batch/v2alpha1
+{{- end }}
+kind: CronJob
+metadata:
+  name: neuvector-cert-upgrader-pod
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: Helm
+spec:
+{{- if .Values.controller.certupgrader.schedule }}
+  schedule: {{ .Values.controller.certupgrader.schedule | quote }}
+{{- else }}
+  schedule: "0 0 1 1 *"
+  suspend: true
+{{- end }}
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: {{ .Values.controller.certupgrader.timeout }}
+      parallelism: 1
+      completions: 1
+      backoffLimit: 6
+      template:
+        metadata:
+          labels:
+            app: neuvector-cert-upgrader-pod
+            release: {{ .Release.Name }}
+            {{- with .Values.controller.certupgrader.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.controller.certupgrader.podAnnotations }}
+          annotations:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+        {{- if .Values.imagePullSecrets }}
+          imagePullSecrets:
+            - name: {{ .Values.imagePullSecrets }}
+        {{- end }}
+        {{- if .Values.controller.certupgrader.nodeSelector }}
+          nodeSelector:
+{{ toYaml .Values.controller.certupgrader.nodeSelector | indent 12 }}
+        {{- end }}
+        {{- if .Values.controller.certupgrader.priorityClassName }}
+          priorityClassName: {{ .Values.controller.certupgrader.priorityClassName }}
+        {{- end }}
+        {{- if .Values.leastPrivilege }}
+          serviceAccountName: cert-upgrader
+          serviceAccount: cert-upgrader
+        {{- else }}
+          serviceAccountName: {{ .Values.serviceAccount }}
+          serviceAccount: {{ .Values.serviceAccount }}
+        {{- end }}
+          restartPolicy: Never
+          {{- if .Values.controller.certupgrader.runAsUser }}
+          securityContext:
+            runAsUser: {{ .Values.controller.certupgrader.runAsUser }}
+          {{- end }}
+          containers:
+            - name: neuvector-cert-upgrader-pod
+              image: {{ include "neuvector.controller.image" . | quote }}
+              imagePullPolicy: {{ .Values.controller.certupgrader.imagePullPolicy }}
+              command: 
+                - /usr/local/bin/upgrader
+                - upgrader-job
+              env:
+              {{- with .Values.controller.certupgrader.env }}
+{{- toYaml . | nindent 14 }}
+              {{- end }}
+{{- end }}

--- a/charts/core/templates/upgrader-lease.yaml
+++ b/charts/core/templates/upgrader-lease.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.internal.autoGenerateCert }}
+apiVersion: coordination.k8s.io/v1
+kind: Lease
+metadata:
+  name: neuvector-cert-upgrader
+spec:
+  leaseTransitions: 0
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -61,10 +61,12 @@ autoGenerateCert: true
 
 defaultValidityPeriod: 365
 
-internal: # enable when cert-manager is installed for the internal certificates
-  certmanager:
+internal: 
+  certmanager: # enable when cert-manager is installed for the internal certificates
     enabled: false
     secretname: neuvector-internal
+  autoGenerateCert: true
+  autoRotateCert: false
 
 controller:
   # If false, controller will not be installed
@@ -285,6 +287,21 @@ controller:
         - Fullname: admin
           Password:
           Role: admin
+  certupgrader:
+    env: []
+    # The cronjob schedule that cert-upgrader will run to check and rotate internal certificate.
+    # default: "" (off)
+    schedule: ""
+    imagePullPolicy: IfNotPresent
+    timeout: 3600 
+    priorityClassName:
+    podLabels: {}
+    podAnnotations: {}
+    nodeSelector:
+      {}
+      # key1: value1
+      # key2: value2
+    runAsUser: # MUST be set for Rancher hardened cluster
 
 enforcer:
   # If false, enforcer will not be installed

--- a/test/role_test.go
+++ b/test/role_test.go
@@ -18,7 +18,7 @@ func TestRoleBinding(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/rolebinding.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 2 {
+	if len(outs) != 4 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }
@@ -98,7 +98,7 @@ func TestRoleBindingLeastPrivilege(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/rolebinding-least.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 2 {
+	if len(outs) != 5 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }

--- a/test/sa_test.go
+++ b/test/sa_test.go
@@ -19,7 +19,7 @@ func TestServiceAccountLeastPrivilege(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/serviceaccount-least.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 6 {
+	if len(outs) != 7 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }


### PR DESCRIPTION
This PR is to support 5.4's internal certificate rotation.
1. Update helm charts to support auto internal cert rotation.
2. Via unit-test, make sure that when the feature is off, resources created is the same as before.

Note that this feature will only be enabled on workloads when `.Values.image.tag > 5.3.10-0`.   