### PR TITLE
Add sources to core chart metadata

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -9,3 +9,6 @@ maintainers:
   - name: becitsthere
     email: support@neuvector.com
 engine: gotpl
+sources:
+  - https://github.com/neuvector/neuvector
+  - https://github.com/neuvector/neuvector-helm


### PR DESCRIPTION
This change adds `sources` to Chart.yaml for the core chart.

Listing sources for a chart is helpful to the users, since it makes it easy to find relevant information about what gets installed. It is parsed by Artifact Hub, so the links will appear [here](https://artifacthub.io/packages/helm/neuvectorcharts/core).

I also hope that this change will make it possible for tools like [Renovate Bot](https://docs.renovatebot.com/) to identify the relevant repositories for this chart and automate fetching of changelogs, etc.

The `sources` field is documented here: https://helm.sh/docs/topics/charts/#the-chartyaml-file