### PR TITLE
NVSHAS-9187 NeuVector LoadBalancer is not reachable

### DIFF
--- a/charts/core/templates/manager-service.yaml
+++ b/charts/core/templates/manager-service.yaml
@@ -21,7 +21,7 @@ spec:
     - port: 8443
       name: manager
       protocol: TCP
-{{- if not .Values.global.azure.enabled }}
+{{- if or (.Capabilities.KubeVersion.GitVersion | contains "-eks") (.Capabilities.KubeVersion.GitVersion | contains "-gke") }}
 {{- if .Values.manager.env.ssl }}
       appProtocol: HTTPS
 {{- else }}

--- a/charts/core/templates/manager-service.yaml
+++ b/charts/core/templates/manager-service.yaml
@@ -21,10 +21,12 @@ spec:
     - port: 8443
       name: manager
       protocol: TCP
+{{- if not .Values.global.azure.enabled }}
 {{- if .Values.manager.env.ssl }}
       appProtocol: HTTPS
 {{- else }}
       appProtocol: HTTP
+{{- end }}
 {{- end }}
   selector:
     app: neuvector-manager-pod


### PR DESCRIPTION
Created HELM changes for Manager service. appProtocol: HTTPS configuration will be added only for AWS EKS and GCP cluster. Azure wouldnt have that configuration hence forth after this merge. Tested on Azure, GCP and AWS EKS cloud.