### PR TITLE
added edge support in schema json for openshift routes

### DIFF
--- a/charts/core/values.schema.json
+++ b/charts/core/values.schema.json
@@ -1071,8 +1071,8 @@
               "description": "If true, create a OpenShift route to expose the management console service"
             },
             "termination": {
-              "enum": ["passthrough", "reencrypt"],
-              "description": "Specify TLS termination for OpenShift route for management console service. Possible passthrough, reencrypt"
+              "enum": ["passthrough", "reencrypt", "edge"],
+              "description": "Specify TLS termination for OpenShift route for management console service. Possible passthrough, reencrypt, edge"
             },
             "host": {
               "type": ["string", "null"],
@@ -1331,8 +1331,8 @@
                   "description": "If true, create a OpenShift route to expose the management console service"
                 },
                 "termination": {
-                  "enum": ["passthrough", "reencrypt"],
-                  "description": "Specify TLS termination for OpenShift route for management console service. Possible passthrough, reencrypt"
+                  "enum": ["passthrough", "reencrypt", "edge"],
+                  "description": "Specify TLS termination for OpenShift route for management console service. Possible passthrough, reencrypt, edge"
                 },
                 "host": {
                   "type": ["string", "null"],


### PR DESCRIPTION
Hello, It seems that the schema file for the Neuvector helm chart does not allow 'edge' as a valid enum for both the "manager" and "cve" deployments. Whereas this is explicitly not supported on the Controller via the comment in the values.yaml: https://github.com/neuvector/neuvector-helm/blob/3e119c148d05422ab24a57c4510f360694156223/charts/core/values.yaml#L110

But the "Manager" and "CVE" both support "edge" termination. So this PR updates the schema to allow the use of "edge" by adding it to the enum and updating the comment to display it as an option.
```
neuvector-helm/charts/core> jq '.properties.manager.properties.route.properties.termination' values.schema.json
{
  "enum": [
    "passthrough",
    "reencrypt",
    "edge"
  ],
  "description": "Specify TLS termination for OpenShift route for management console service. Possible passthrough, reencrypt, edge"
}
neuvector-helm/charts/core> jq '.properties.cve.properties.adapter.properties.route.properties.termination' values.schema.json
{
  "enum": [
    "passthrough",
    "reencrypt",
    "edge"
  ],
  "description": "Specify TLS termination for OpenShift route for management console service. Possible passthrough, reencrypt, edge"
```

More information about OpenShift Routes can be found here:
https://docs.openshift.com/container-platform/4.16/networking/routes/secured-routes.html#nw-ingress-creating-an-edge-route-with-a-custom-certificate_secured-routes

Thanks!