### PR TITLE
fix: volumeMounts for both internl and SSL

### DIFF
--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -114,7 +114,8 @@ spec:
               subPath: {{ .Values.cve.adapter.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
-          {{- else if .Values.cve.adapter.certificate.secret }}
+          {{- end }}
+          {{- if .Values.cve.adapter.certificate.secret }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: {{ .Values.cve.adapter.certificate.keyFile }}
               name: cert


### PR DESCRIPTION
In the previous PR, when internal.certmanager is specified, TLS certificate settings will be ignored.

This PR fixes the issue. 