### PR TITLE
Adding support for CTRL_SEARCH_REGISTRIES env variable NVSHAS-9255

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -68,6 +68,7 @@ Parameter | Description | Default | Notes
 `controller.pvc.existingClaim` | If `false`, a new PVC will be created. If a string is provided, an existing PVC with this name will be used. | `false` |
 `controller.pvc.storageClass` | Storage Class to be used | `default` |
 `controller.pvc.capacity` | Storage capacity | `1Gi` |
+`controller.searchRegistries` | Custom search registries for Admission control | `nil` |
 `controller.azureFileShare.enabled` | If true, enable the usage of an existing or statically provisioned Azure File Share | `false` |
 `controller.azureFileShare.secretName` | The name of the secret containing the Azure file share storage account name and key | `nil` |
 `controller.azureFileShare.shareName` | The name of the Azure file share to use | `nil` |

--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -158,6 +158,10 @@ spec:
             - name: NO_DEFAULT_ADMIN
               value: "1"
           {{- end }}
+          {{- if .Values.controller.searchRegistries }}
+            - name: CTRL_SEARCH_REGISTRIES
+              value: "{{ .Values.controller.searchRegistries }}"
+          {{- end }}
           {{- if or .Values.internal.certmanager.enabled .Values.controller.internal.certificate.secret }}
           {{- else if .Values.internal.autoGenerateCert }}
             - name: AUTO_INTERNAL_CERT

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -89,6 +89,7 @@ controller:
   priorityClassName:
   podLabels: {}
   podAnnotations: {}
+  searchRegistries:
   env: []
   affinity:
     podAntiAffinity:


### PR DESCRIPTION
Adding support for CTRL_SEARCH_REGISTRIES env variable NVSHAS-9255.

helm deployment was tested with and w/o CTRL_SEARCH_REGISTRIES  env variable. Feature works as expected.