### PR TITLE
feat: NVSHAS-9382 allow providing TLS certificates

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -39,7 +39,6 @@ spec:
         {{- with .Values.controller.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.controller.secret.enabled .Values.controller.configmap.enabled .Values.controller.podAnnotations (eq "true" (toString .Values.autoGenerateCert)) }}
       annotations:
         {{- if .Values.controller.secret.enabled }}
         checksum/init-secret: {{ include (print $.Template.BasePath "/init-secret.yaml") . | sha256sum }}
@@ -47,13 +46,12 @@ spec:
         {{- if .Values.controller.configmap.enabled }}
         checksum/init-configmap: {{ include (print $.Template.BasePath "/init-configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if eq "true" (toString .Values.autoGenerateCert) }}
+        {{- if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.controller.certificate.key .Values.controller.certificate.certificate) }}
         checksum/controller-secret: {{ include (print $.Template.BasePath "/controller-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.controller.podAnnotations }}
         {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
         {{- end }}
-      {{- end }}
     spec:
       {{- if .Values.controller.affinity }}
       affinity:
@@ -209,7 +207,7 @@ spec:
               subPath: {{ .Values.controller.certificate.pemFile }}
               name: usercert
               readOnly: true
-          {{- else if eq "true" (toString .Values.autoGenerateCert) }}
+          {{- else if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.controller.certificate.key .Values.controller.certificate.certificate) }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: ssl-cert.key
               name: cert
@@ -285,7 +283,7 @@ spec:
               - secret:
                   name: neuvector-secret
                   optional: true
-      {{- if eq "true" (toString .Values.autoGenerateCert) }}
+      {{- if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.controller.certificate.key .Values.controller.certificate.certificate) }}
         - name: cert
           secret:
             secretName: neuvector-controller-secret

--- a/charts/core/templates/controller-secret.yaml
+++ b/charts/core/templates/controller-secret.yaml
@@ -1,7 +1,12 @@
 {{- if .Values.controller.enabled -}}
-{{- if eq "true" (toString .Values.autoGenerateCert) }}
+{{- if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.controller.certificate.key .Values.controller.certificate.certificate) }}
+{{- $cert := (dict) }}
+{{- if and .Values.controller.certificate.key .Values.controller.certificate.certificate }}
+{{- $cert = (dict "Key" .Values.controller.certificate.key "Cert" .Values.controller.certificate.certificate ) }}
+{{- else }}
 {{- $cn := "neuvector" }}
-{{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
+{{- $cert = genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
+{{- end }}
 
 apiVersion: v1
 kind: Secret

--- a/charts/core/templates/manager-deployment.yaml
+++ b/charts/core/templates/manager-deployment.yaml
@@ -24,15 +24,13 @@ spec:
         {{- with .Values.manager.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.manager.podAnnotations (eq "true" (toString .Values.autoGenerateCert)) }}
       annotations:
-        {{- if eq "true" (toString .Values.autoGenerateCert) }}
+        {{- if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.manager.certificate.key .Values.manager.certificate.certificate) }}
         checksum/manager-secret: {{ include (print $.Template.BasePath "/manager-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.manager.podAnnotations }}
         {{- toYaml .Values.manager.podAnnotations | nindent 8 }}
         {{- end }}
-      {{- end }}
     spec:
       {{- if .Values.manager.affinity }}
       affinity:
@@ -111,7 +109,7 @@ spec:
               subPath: {{ .Values.manager.certificate.pemFile }}
               name: cert
               readOnly: true
-          {{- else if eq "true" (toString .Values.autoGenerateCert) }}
+          {{- else if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.manager.certificate.key .Values.manager.certificate.certificate) }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: ssl-cert.key
               name: cert
@@ -174,7 +172,7 @@ spec:
         - name: cert
           secret:
             secretName: {{ .Values.manager.certificate.secret }}
-      {{- else if eq "true" (toString .Values.autoGenerateCert) }}
+      {{- else if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.manager.certificate.key .Values.manager.certificate.certificate) }}
         - name: cert
           secret:
             secretName: neuvector-manager-secret

--- a/charts/core/templates/manager-secret.yaml
+++ b/charts/core/templates/manager-secret.yaml
@@ -1,7 +1,12 @@
 {{- if .Values.manager.enabled -}}
-{{- if eq "true" (toString .Values.autoGenerateCert) }}
+{{- if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.manager.certificate.key .Values.manager.certificate.certificate) }}
+{{- $cert := (dict) }}
+{{- if and .Values.manager.certificate.key .Values.manager.certificate.certificate }}
+{{- $cert = (dict "Key" .Values.manager.certificate.key "Cert" .Values.manager.certificate.certificate ) }}
+{{- else }}
 {{- $cn := "neuvector" }}
-{{- $cert := genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
+{{- $cert = genSelfSignedCert $cn nil (list $cn) (.Values.defaultValidityPeriod | int) -}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/core/templates/registry-adapter-secret.yaml
+++ b/charts/core/templates/registry-adapter-secret.yaml
@@ -1,7 +1,13 @@
 {{- if .Values.cve.adapter.enabled -}}
-{{- if eq "true" (toString .Values.autoGenerateCert) }}
+{{- if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.cve.adapter.certificate.key .Values.cve.adapter.certificate.certificate) }}
+{{- $cert := (dict) }}
+{{- if and .Values.cve.adapter.certificate.key .Values.cve.adapter.certificate.certificate }}
+{{- $cert = (dict "Key" .Values.cve.adapter.certificate.key "Cert" .Values.cve.adapter.certificate.certificate ) }}
+{{- else }}
 {{- $cn := "neuvector" }}
-{{- $cert := genSelfSignedCert $cn nil (list $cn "neuvector-service-registry-adapter.cattle-neuvector-system.svc.cluster.local" "neuvector-service-registry-adapter") (.Values.defaultValidityPeriod | int) -}}
+{{- $cert = genSelfSignedCert $cn nil (list $cn "neuvector-service-registry-adapter.cattle-neuvector-system.svc.cluster.local" "neuvector-service-registry-adapter") (.Values.defaultValidityPeriod | int) -}}
+{{- end }}
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -28,15 +28,13 @@ spec:
         {{- with .Values.cve.adapter.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if or .Values.cve.adapter.podAnnotations (eq "true" (toString .Values.autoGenerateCert)) }}
       annotations:
-        {{- if eq "true" (toString .Values.autoGenerateCert) }}
+        {{- if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.cve.adapter.certificate.key .Values.cve.adapter.certificate.certificate) }}
         checksum/registry-adapter-secret: {{ include (print $.Template.BasePath "/registry-adapter-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.cve.adapter.podAnnotations }}
         {{- toYaml .Values.cve.adapter.podAnnotations | nindent 8 }}
         {{- end }}
-      {{- end }}
     spec:
       {{- if .Values.cve.adapter.affinity }}
       affinity:
@@ -135,7 +133,7 @@ spec:
               subPath: {{ .Values.cve.adapter.certificate.pemFile }}
               name: cert
               readOnly: true
-          {{- else if eq "true" (toString .Values.autoGenerateCert) }}
+          {{- else if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.cve.adapter.certificate.key .Values.cve.adapter.certificate.certificate) }}
             - mountPath: /etc/neuvector/certs/ssl-cert.key
               subPath: ssl-cert.key
               name: cert
@@ -157,7 +155,7 @@ spec:
         - name: cert
           secret:
             secretName: {{ .Values.cve.adapter.certificate.secret }}
-      {{- else if eq "true" (toString .Values.autoGenerateCert) }}
+      {{- else if or (eq "true" (toString .Values.autoGenerateCert)) (and .Values.cve.adapter.certificate.key .Values.cve.adapter.certificate.certificate) }}
         - name: cert
           secret:
             secretName: neuvector-registry-adapter-secret

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -148,6 +148,12 @@ controller:
     secret: ""
     keyFile: tls.key
     pemFile: tls.pem
+    #key: |
+    #  -----BEGIN PRIVATE KEY-----
+    #  -----END PRIVATE KEY-----
+    #certificate: |
+    #  -----BEGIN CERTIFICATE-----
+    #  -----END CERTIFICATE-----
   internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
     certificate:
       secret: ""
@@ -384,6 +390,12 @@ manager:
     secret: ""
     keyFile: tls.key
     pemFile: tls.pem
+    #key: |
+    #  -----BEGIN PRIVATE KEY-----
+    #  -----END PRIVATE KEY-----
+    #certificate: |
+    #  -----BEGIN CERTIFICATE-----
+    #  -----END CERTIFICATE-----
   ingress:
     enabled: false
     host: # MUST be set, if ingress is enabled
@@ -455,6 +467,12 @@ cve:
       secret: ""
       keyFile: tls.key
       pemFile: tls.crt
+    #key: |
+    #  -----BEGIN PRIVATE KEY-----
+    #  -----END PRIVATE KEY-----
+    #certificate: |
+    #  -----BEGIN CERTIFICATE-----
+    #  -----END CERTIFICATE-----
     harbor:
       protocol: https
       secretName:


### PR DESCRIPTION
Allow users to provide TLS certificates in helm charts.  When both user-specified certificate and autoGenerate are enabled, user-specified certificate will take precedence. 