### PR TITLE
fix: NVSHAS-9389 add missing namespace fields

### DIFF
--- a/charts/core/templates/controller-lease.yaml
+++ b/charts/core/templates/controller-lease.yaml
@@ -3,6 +3,7 @@ apiVersion: coordination.k8s.io/v1
 kind: Lease
 metadata:
   name: neuvector-controller
+  namespace: {{ .Release.Namespace }}
 spec:
   leaseTransitions: 0
 {{- end }}

--- a/charts/core/templates/controller-secret.yaml
+++ b/charts/core/templates/controller-secret.yaml
@@ -28,6 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: neuvector-internal-certs
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 {{- end}}
 {{- end}}

--- a/charts/core/templates/registry-adapter-secret.yaml
+++ b/charts/core/templates/registry-adapter-secret.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: neuvector-registry-adapter-secret
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   ssl-cert.key: {{ include "neuvector.secrets.lookup" (dict "namespace" .Release.Namespace "secret" "neuvector-registry-adapter-secret" "key" "ssl-cert.key" "defaultValue" $cert.Key) }}

--- a/charts/core/templates/upgrader-lease.yaml
+++ b/charts/core/templates/upgrader-lease.yaml
@@ -3,6 +3,7 @@ apiVersion: coordination.k8s.io/v1
 kind: Lease
 metadata:
   name: neuvector-cert-upgrader
+  namespace: {{ .Release.Namespace }}
 spec:
   leaseTransitions: 0
 {{- end }}


### PR DESCRIPTION
During code review, it was found that some fields don't have namespace specified.  It shouldn't cause any issue in the normal circumstance, but it's better to sync with other resources.  