### PR TITLE
fix: NVSHAS-9442 issues on argocd

### DIFF
--- a/charts/core/templates/role.yaml
+++ b/charts/core/templates/role.yaml
@@ -47,6 +47,7 @@ rules:
   resources:
   - leases
   verbs:
+  - create
   - get
   - update
 ---

--- a/charts/core/templates/upgrader-cronjob.yaml
+++ b/charts/core/templates/upgrader-cronjob.yaml
@@ -10,6 +10,8 @@ kind: CronJob
 metadata:
   name: neuvector-cert-upgrader-pod
   namespace: {{ .Release.Namespace }}
+  annotations:
+    cert-upgrader-uid: ""
   labels:
     chart: {{ template "neuvector.chart" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
On ArgoCD, no default annotations would be created, which fails the attempt to update annotations from cert upgrader.

This issue is fixed by providing the default annotation to cert upgrader's cronjob.
