### PR TITLE
fix: NVSHAS-9479 emptyDir should be mounted when autoGenerate is enabled

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -251,7 +251,7 @@ spec:
               subPath: {{ .Values.controller.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
-          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+          {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
             - mountPath: /etc/neuvector/certs/internal/
               name: internal-cert-dir
           {{- end }}
@@ -321,7 +321,7 @@ spec:
         - name: internal-cert
           secret:
             secretName: {{ .Values.controller.internal.certificate.secret }}
-      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+      {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
         - name: internal-cert-dir
           emptyDir:
             sizeLimit: 50Mi

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -161,7 +161,7 @@ spec:
               subPath: {{ .Values.enforcer.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
-          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+          {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
             - mountPath: /etc/neuvector/certs/internal/
               name: internal-cert-dir
           {{- end }}
@@ -203,7 +203,7 @@ spec:
         - name: internal-cert
           secret:
             secretName: {{ .Values.enforcer.internal.certificate.secret }}
-      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+      {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
         - name: internal-cert-dir
           emptyDir:
             sizeLimit: 50Mi

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -120,7 +120,7 @@ spec:
               subPath: {{ .Values.cve.adapter.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
-          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+          {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
             - mountPath: /etc/neuvector/certs/internal/
               name: internal-cert-dir
           {{- end }}
@@ -164,7 +164,7 @@ spec:
         - name: internal-cert
           secret:
             secretName: {{ .Values.cve.adapter.internal.certificate.secret }}
-      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+      {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
         - name: internal-cert-dir
           emptyDir:
             sizeLimit: 50Mi

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -121,7 +121,7 @@ spec:
               subPath: {{ .Values.cve.scanner.internal.certificate.caFile }}
               name: internal-cert
               readOnly: true
-          {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+          {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
             - mountPath: /etc/neuvector/certs/internal/
               name: internal-cert-dir
           {{- end }}
@@ -131,7 +131,7 @@ spec:
         - name: internal-cert
           secret:
             secretName: {{ .Values.cve.scanner.internal.certificate.secret }}
-      {{- else if and .Values.internal.autoRotateCert (not $pre540) }}
+      {{- else if and .Values.internal.autoGenerateCert (not $pre540) }}
         - name: internal-cert-dir
           emptyDir:
             sizeLimit: 50Mi


### PR DESCRIPTION
Make sure in OpenShift case, scanner can still update internal certificates. 