### PR TITLE
fix: NVSHAS-9546 make scanner not load cert

### DIFF
--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -98,7 +98,7 @@ spec:
               value: {{ .Values.cve.scanner.dockerPath }}
           {{- end }}
           {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
-          {{- else if .Values.internal.autoGenerateCert }}
+          {{- else if (and .Values.internal.autoGenerateCert (not $pre540))}} # for pre540, the latest scanner will still be used.
             - name: AUTO_INTERNAL_CERT
               value: "1"
           {{- end }}


### PR DESCRIPTION
Make scanner not reload certs when tag is pre54