### PR TITLE
fix: NVSHAS-9546 make scanner not load cert

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -176,7 +176,7 @@ spec:
               value: "{{ .Values.controller.searchRegistries }}"
           {{- end }}
           {{- if or .Values.internal.certmanager.enabled .Values.controller.internal.certificate.secret }}
-          {{- else if .Values.internal.autoGenerateCert }}
+          {{- else if (and .Values.internal.autoGenerateCert (not $pre540))}}
             - name: AUTO_INTERNAL_CERT
               value: "1"
           {{- end }}

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -109,7 +109,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           {{- if or .Values.internal.certmanager.enabled .Values.enforcer.internal.certificate.secret }}
-          {{- else if .Values.internal.autoGenerateCert }}
+          {{- else if (and .Values.internal.autoGenerateCert (not $pre540))}}
             - name: AUTO_INTERNAL_CERT
               value: "1"
           {{- end }}

--- a/charts/core/templates/registry-adapter.yaml
+++ b/charts/core/templates/registry-adapter.yaml
@@ -99,7 +99,7 @@ spec:
                   key: password
             {{- end }}
             {{- if or .Values.internal.certmanager.enabled .Values.cve.adapter.internal.certificate.secret }}
-            {{- else if .Values.internal.autoGenerateCert }}
+            {{- else if (and .Values.internal.autoGenerateCert (not $pre540))}}
             - name: AUTO_INTERNAL_CERT
               value: "1"
             {{- end }}

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -98,7 +98,7 @@ spec:
               value: {{ .Values.cve.scanner.dockerPath }}
           {{- end }}
           {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
-          {{- else if (and .Values.internal.autoGenerateCert (not $pre540))}} # for pre540, the latest scanner will still be used.
+          {{- else if (and .Values.internal.autoGenerateCert (not $pre540))}}
             - name: AUTO_INTERNAL_CERT
               value: "1"
           {{- end }}


### PR DESCRIPTION
Extend the changes to other components. 

Verified that the environment variable is generated based on image tag value with below commands.
```
helm template charts/core/ --set tag=5.3.3 --set cve.adapter.enabled=true
helm template charts/core/ --set tag=5.4.0 --set cve.adapter.enabled=true
```