### PR TITLE
[NVSHAS-9612] Add copy in runtime to copy the prime data into emptyDir

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -108,11 +108,12 @@ spec:
           image: "{{ .Values.registry }}/{{ .Values.controller.prime.image.repository }}:{{ .Values.controller.prime.image.tag }}"
           {{- end }}
           imagePullPolicy: Always
+          command: ['sh', '-c', 'cp -a /usr/share/compliance-config/*.yaml /data/compliance-config/']
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-          - mountPath: /usr/share
+          - mountPath: /data/compliance-config/
             name: prime-config
       {{- end }}
       containers:


### PR DESCRIPTION
### Summary

- Copy the prime data in runtime not in dockerfile, [Reference](https://stackoverflow.com/questions/65471145/sharing-non-persistent-volume-between-containers-in-a-pod )

