### PR TITLE
feat: NVSHAS-9443 allow ArgoCD users to disable lease creation

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -295,6 +295,7 @@ Parameter | Description | Default | Notes
 `crdwebhooksvc.enabled` | Enable crd service | `true` |
 `crdwebhook.enabled` | Create crd resources | `true` |
 `crdwebhook.type` | crd webhook type | `ClusterIP` |
+`lease.enabled` | Create lease object or not | `true` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/core/templates/controller-lease.yaml
+++ b/charts/core/templates/controller-lease.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.lease.enabled }}
 {{- if .Values.internal.autoGenerateCert }}
 apiVersion: coordination.k8s.io/v1
 kind: Lease
@@ -5,4 +6,5 @@ metadata:
   name: neuvector-controller
 spec:
   leaseTransitions: 0
+{{- end }}
 {{- end }}

--- a/charts/core/templates/upgrader-lease.yaml
+++ b/charts/core/templates/upgrader-lease.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.lease.enabled }}
 {{- if .Values.internal.autoGenerateCert }}
 apiVersion: coordination.k8s.io/v1
 kind: Lease
@@ -6,3 +7,5 @@ metadata:
 spec:
   leaseTransitions: 0
 {{- end }}
+{{- end }}
+

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -636,3 +636,6 @@ crdwebhooksvc:
 crdwebhook:
   enabled: true
   type: ClusterIP
+
+lease:
+  enabled: true


### PR DESCRIPTION
ArgoCD doesn't allow lease objects to be created and generate warnings. With this option, ArgoCD users can prevent lease objects from being created. (controller and upgrader will create them instead.)