### PR TITLE
feat: NVSHAS-9686 provide a better CN for registry-adapter

### DIFF
--- a/charts/core/templates/registry-adapter-secret.yaml
+++ b/charts/core/templates/registry-adapter-secret.yaml
@@ -5,7 +5,7 @@
 {{- $cert = (dict "Key" .Values.cve.adapter.certificate.key "Cert" .Values.cve.adapter.certificate.certificate ) }}
 {{- else }}
 {{- $cn := "neuvector" }}
-{{- $cert = genSelfSignedCert $cn nil (list $cn "neuvector-service-registry-adapter.cattle-neuvector-system.svc.cluster.local" "neuvector-service-registry-adapter") (.Values.defaultValidityPeriod | int) -}}
+{{- $cert = genSelfSignedCert $cn nil (list $cn (print "neuvector-service-registry-adapter." (default "neuvector" .Release.Namespace) ".svc.cluster.local") "neuvector-service-registry-adapter") (.Values.defaultValidityPeriod | int) -}}
 {{- end }}
 
 apiVersion: v1


### PR DESCRIPTION
Originally registry-adapter's default CN uses rancher's default setting. In this commit, the installation namespace will be used to generate the certificate.