### PR TITLE
Promote version to 5.4.2

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 name: core
 apiVersion: v1
-version: 2.8.3
-appVersion: 5.4.1
+version: 2.8.4
+appVersion: 5.4.2
 description: Helm chart for NeuVector's core services
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -5,7 +5,7 @@
 openshift: false
 
 registry: docker.io
-tag: 5.4.1
+tag: 5.4.2
 oem:
 imagePullSecrets:
 psp: false
@@ -317,7 +317,7 @@ controller:
     enabled: false
     image:
       repository: neuvector/compliance-config
-      tag: latest
+      tag: 1.0.2
       hash:
 enforcer:
   # If false, enforcer will not be installed
@@ -446,7 +446,7 @@ cve:
     enabled: false
     image:
       repository: neuvector/registry-adapter
-      tag: 0.1.3
+      tag: 0.1.5
       hash:
     priorityClassName:
     resources:
@@ -537,7 +537,7 @@ cve:
     image:
       registry: ""
       repository: neuvector/updater
-      tag: latest
+      tag: 0.0.1
       hash:
     schedule: "0 0 * * *"
     priorityClassName:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -69,7 +69,7 @@ internal:
     enabled: false
     secretname: neuvector-internal
   autoGenerateCert: true
-  autoRotateCert: false
+  autoRotateCert: true
 
 controller:
   # If false, controller will not be installed
@@ -568,7 +568,7 @@ cve:
     image:
       registry: ""
       repository: neuvector/scanner
-      tag: latest
+      tag: "6"
       hash:
     priorityClassName:
     resources:

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -366,7 +366,7 @@ manager:
   #      - name: CUSTOM_PAGE_FOOTER_COLOR
   #        value: "#FFFFFF"
   svc:
-    type: NodePort # should be set to - ClusterIP
+    type: ClusterIP
     nodePort:  
     loadBalancerIP:
     annotations:
@@ -484,7 +484,7 @@ cve:
       protocol: https
       secretName:
     svc:
-      type: NodePort # should be set to - ClusterIP
+      type: ClusterIP
       loadBalancerIP:
       annotations:
         {}

--- a/charts/crd/Chart.yaml
+++ b/charts/crd/Chart.yaml
@@ -1,7 +1,7 @@
 name: crd
 apiVersion: v1
-version: 2.8.3
-appVersion: 5.4.1
+version: 2.8.4
+appVersion: 5.4.2
 description: Helm chart for NeuVector's CRD services
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4

--- a/charts/monitor/Chart.yaml
+++ b/charts/monitor/Chart.yaml
@@ -1,7 +1,7 @@
 name: monitor
 apiVersion: v1
-version: 2.8.3
-appVersion: 1-1.0.0
+version: 2.8.4
+appVersion: 1.0.1
 description: Helm chart for NeuVector monitor services
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -11,7 +11,7 @@ exporter:
   enabled: true
   image:
     repository: neuvector/prometheus-exporter
-    tag: latest
+    tag: 1.0.2
   # changes this to a readonly user !
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -272,7 +272,7 @@ func TestManagerService(t *testing.T) {
 	var svc corev1.Service
 	helm.UnmarshalK8SYaml(t, outs[0], &svc)
 
-	checkManagerService(t, svc, "NodePort")
+	checkManagerService(t, svc, "ClusterIP")
 }
 
 func TestManagerServiceLB(t *testing.T) {


### PR DESCRIPTION
This PR includes below changes:
- Increment charts version to 2.8.4 and appVersion to 5.4.2.
- Enable internal.autoRotateCert by default.
- Update image tags to use SLSA images. 
- Switch scanner tag to `6`. 
- Make ClusterIP as the default option for managersvc.