### PR TITLE
fix: NVSHAS-9662 fix inconsistent role bindings

### DIFF
--- a/charts/core/templates/rolebinding-least.yaml
+++ b/charts/core/templates/rolebinding-least.yaml
@@ -98,7 +98,6 @@ subjects:
 userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:controller
 {{- end }}
-{{- end }}
 ---
 {{- if $oc3 }}
 apiVersion: authorization.openshift.io/v1
@@ -127,6 +126,7 @@ subjects:
 {{- if $oc3 }}
 userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:cert-upgrader
+{{- end }}
 {{- end }}
 ---
 {{- if $oc3 }}

--- a/charts/core/templates/rolebinding.yaml
+++ b/charts/core/templates/rolebinding.yaml
@@ -110,7 +110,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount }}
   namespace: {{ .Release.Namespace }}
-{{- end }}
 ---
 {{- if $oc3 }}
 apiVersion: authorization.openshift.io/v1
@@ -168,6 +167,7 @@ subjects:
 {{- if $oc3 }}
 userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:cert-upgrader
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Remove a few role bindings when internal.autoGenerateCert is disabled