### PR TITLE
chore: bump compliance-config version

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -317,7 +317,7 @@ controller:
     enabled: false
     image:
       repository: neuvector/compliance-config
-      tag: 1.0.2
+      tag: 1.0.3
       hash:
 enforcer:
   # If false, enforcer will not be installed


### PR DESCRIPTION
Bump compliance-config version to 1.0.3