### PR TITLE
NVSHAS-9426 Add hostPath for scanner to helm chart

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -8,6 +8,22 @@ Because the CRD (Custom Resource Definition) policies can be deployed before Neu
 ## Choosing container runtime
 Prior to 5.3 release, the user has to specify the correct container runtime type and its socket path. In 5.3.0 release, the enforcer is able to automatically detect the container runtime at its default socket location. The settings of docker/containerd/crio/k8s/bottlerocket become deprecated. If the container runtime socket is not at the default location, please specify it using 'runtimePath' field. In the meantime, the controller does not require the runtime socket to be mounted any more.
 
+
+## Scan caching
+Scan caching can be enabled by editing values.yaml or creating below override file and pass them with "-f" option on HELM commands.
+```console
+cve:
+  scanner:
+    volumes:
+      - name: scan-cache
+        hostPath:
+          path: /tmp/
+          type: ""
+    volumeMounts:
+      - mountPath: /tmp/images/caches
+        name: scan-cache
+```
+
 ## Configuration
 
 The following table lists the configurable parameters of the NeuVector chart and their default values.

--- a/charts/core/templates/scanner-deployment.yaml
+++ b/charts/core/templates/scanner-deployment.yaml
@@ -125,6 +125,9 @@ spec:
             - mountPath: /etc/neuvector/certs/internal/
               name: internal-cert-dir
           {{- end }}
+          {{- with .Values.cve.scanner.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
       restartPolicy: Always
       volumes:
       {{- if or .Values.internal.certmanager.enabled .Values.cve.scanner.internal.certificate.secret }}
@@ -135,5 +138,8 @@ spec:
         - name: internal-cert-dir
           emptyDir:
             sizeLimit: 50Mi
+      {{- end }}
+      {{- with .Values.cve.scanner.volumes }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -596,7 +596,8 @@ cve:
         keyFile: tls.key
         pemFile: tls.crt
         caFile: ca.crt # must be the same CA for all internal.
-
+    volumes: 
+    volumeMounts:
 resources:
   {}
   # limits:


### PR DESCRIPTION
Users can pass volumes and volumeMounts using override as below,

```
neuvector@Host-01-RKE2:~/test/neuvector-helm-vj/charts/core$ cat override.yaml
cve:
  scanner:
    volumes:
      - name: scan-cache
        hostPath:
          path: /tmp/
          type: ""
    volumeMounts:
      - mountPath: /tmp/images/caches
        name: scan-cache
```

