### PR TITLE
NVSHAS-9748 [Helm] NV helm update for supporting name referral for common groups in CRD

### DIFF
--- a/charts/core/templates/clusterrole.yaml
+++ b/charts/core/templates/clusterrole.yaml
@@ -97,6 +97,31 @@ rules:
 
 ---
 
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRole
+metadata:
+  name: neuvector-binding-nvgroupdefinitions
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - neuvector.com
+  resources:
+  - nvgroupdefinitions
+  verbs:
+  - get
+  - list
+  - delete
+
+---
+
 {{- if $oc4 }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/core/templates/crd-role-least.yaml
+++ b/charts/core/templates/crd-role-least.yaml
@@ -400,4 +400,35 @@ userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:controller
 {{- end }}
 
+---
+
+# ClusterRoleBinding for NeuVector to manage name referral for common groups
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: neuvector-binding-nvgroupdefinitions
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- end }}
+  name: neuvector-binding-nvgroupdefinitions
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:controller
+{{- end }}
+
 {{- end }}

--- a/charts/core/templates/crd-role.yaml
+++ b/charts/core/templates/crd-role.yaml
@@ -400,4 +400,35 @@ userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount }}
 {{- end }}
 
+---
+
+# Clusterrolebinding for Neuvector to manage name referral for common groups
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: neuvector-binding-nvgroupdefinitions
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- end }}
+  name: neuvector-binding-nvgroupdefinitions
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount }}
+{{- end }}
+
 {{- end }}

--- a/charts/core/templates/crd.yaml
+++ b/charts/core/templates/crd.yaml
@@ -72,6 +72,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -143,6 +145,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -218,6 +222,8 @@ spec:
                         type: array
                       name:
                         type: string
+                      name_referral:
+                        type: boolean
                       original_name:
                         type: string
                       mon_metric:
@@ -351,6 +357,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -422,6 +430,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -497,6 +507,8 @@ spec:
                         type: array
                       name:
                         type: string
+                      name_referral:
+                        type: boolean
                       original_name:
                         type: string
                       mon_metric:
@@ -971,6 +983,65 @@ spec:
                 type: object
             required:
             - profile
+            type: object
+        type: object
+{{- end }}
+---
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
+kind: CustomResourceDefinition
+metadata:
+  name: nvgroupdefinitions.neuvector.com
+spec:
+  group: neuvector.com
+  names:
+    kind: NvGroupDefinition
+    listKind: NvGroupDefinitionList
+    plural: nvgroupdefinitions
+    singular: nvgroupdefinition
+  scope: Namespaced
+{{- if (semverCompare "<1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+  version: v1
+{{- end }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              selector:
+                properties:
+                  comment:
+                    type: string
+                  criteria:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        op:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - op
+                      - value
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - selector
             type: object
         type: object
 {{- end }}

--- a/charts/crd/templates/crd.yaml
+++ b/charts/crd/templates/crd.yaml
@@ -74,6 +74,8 @@ spec:
                           type: string
                         original_name:
                           type: string
+                        name_referral:
+                          type: boolean
                       required:
                       - name
                       type: object
@@ -143,6 +145,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -218,6 +222,8 @@ spec:
                         type: array
                       name:
                         type: string
+                      name_referral:
+                        type: boolean
                       original_name:
                         type: string
                       mon_metric:
@@ -352,6 +358,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -423,6 +431,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -498,6 +508,8 @@ spec:
                         type: array
                       name:
                         type: string
+                      name_referral:
+                        type: boolean
                       original_name:
                         type: string
                       mon_metric:
@@ -977,6 +989,65 @@ spec:
                 type: object
             required:
             - profile
+            type: object
+        type: object
+{{- end }}
+---
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
+kind: CustomResourceDefinition
+metadata:
+  name: nvgroupdefinitions.neuvector.com
+spec:
+  group: neuvector.com
+  names:
+    kind: NvGroupDefinition
+    listKind: NvGroupDefinitionList
+    plural: nvgroupdefinitions
+    singular: nvgroupdefinition
+  scope: Namespaced
+{{- if (semverCompare "<1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+  version: v1
+{{- end }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              selector:
+                properties:
+                  comment:
+                    type: string
+                  criteria:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        op:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - op
+                      - value
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - selector
             type: object
         type: object
 {{- end }}

--- a/test/crd_test.go
+++ b/test/crd_test.go
@@ -17,7 +17,7 @@ func TestCRD(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/crd.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 7 {
+	if len(outs) != 8 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }
@@ -33,7 +33,7 @@ func TestCoreCRD(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/crd.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 7 {
+	if len(outs) != 8 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }

--- a/test/role_test.go
+++ b/test/role_test.go
@@ -34,7 +34,7 @@ func TestClusterRole(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/clusterrole.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 3 {
+	if len(outs) != 4 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }


### PR DESCRIPTION
Add helm chart support for referral for common groups in CRD on core and crd chart.
Files changed in core chart,

- crd.yaml
- crd-role.yaml
- crd-role-least.yaml
- clusterrole.yaml

File changed in crd chart,

- crd.yaml

Files changed in unit-test for new resource addition,

- crd_test.go
- role_test.go
