### PR TITLE
add port definition to exporter deployment

### DIFF
--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -71,5 +71,9 @@ spec:
             {{ else }}
                 name: neuvector-prometheus-exporter-pod-secret
             {{- end }}
+            - port:
+                name: metrics
+                containerPort: 8068
+                protocol: TCP
       restartPolicy: Always
 {{- end }}

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -71,7 +71,7 @@ spec:
             {{ else }}
                 name: neuvector-prometheus-exporter-pod-secret
             {{- end }}
-            - port:
+            - ports:
                 name: metrics
                 containerPort: 8068
                 protocol: TCP

--- a/charts/monitor/templates/exporter-deployment.yaml
+++ b/charts/monitor/templates/exporter-deployment.yaml
@@ -71,9 +71,9 @@ spec:
             {{ else }}
                 name: neuvector-prometheus-exporter-pod-secret
             {{- end }}
-            - ports:
-                name: metrics
-                containerPort: 8068
-                protocol: TCP
+          ports:
+           - name: metrics
+             containerPort: 8068
+             protocol: TCP
       restartPolicy: Always
 {{- end }}


### PR DESCRIPTION
In GCP the Google Managed Prometheus (GMP) [PodMonitoring](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#gmp-pod-monitoring) looks at the Pod definition for the named Port as the scrape source and not the standard Prometheus annotations. This adds in that named port to the deployment of the exporter so GMP can scrape it for metrics.