### PR TITLE
Added missing tolerations config for cronjobs

### DIFF
--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -165,6 +165,7 @@ Parameter | Description | Default | Notes
 `controller.certupgrader.priorityClassName` | cert upgrader priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
 `controller.certupgrader.podLabels` | Specify the pod labels. | `{}` |
 `controller.certupgrader.podAnnotations` | Specify the pod annotations. | `{}` |
+`controller.certupgrader.tolerations` | List of node taints to tolerate | `[]` | other taints can be added after the default
 `controller.certupgrader.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
 `controller.certupgrader.runAsUser` | Specify the run as User ID | `nil` |
 `controller.certupgrader.imagePullPolicy` | cert upgrader image pull policy | `IfNotPresent` |
@@ -282,6 +283,7 @@ Parameter | Description | Default | Notes
 `cve.updater.podLabels` | Specify the pod labels. | `{}` |
 `cve.updater.podAnnotations` | Specify the pod annotations. | `{}` |
 `cve.updater.schedule` | cronjob cve updater schedule | `0 0 * * *` |
+`cve.updater.tolerations` | List of node taints to tolerate | `[]` | other taints can be added after the default
 `cve.updater.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
 `cve.updater.runAsUser` | Specify the run as User ID | `nil` |
 `cve.scanner.enabled` | If true, cve scanners will be deployed | `true` |

--- a/charts/core/templates/updater-cronjob.yaml
+++ b/charts/core/templates/updater-cronjob.yaml
@@ -34,6 +34,10 @@ spec:
           imagePullSecrets:
             - name: {{ .Values.imagePullSecrets }}
         {{- end }}
+        {{- if .Values.cve.updater.tolerations }}
+          tolerations:
+{{ toYaml .Values.cve.updater.tolerations | indent 12 }}
+        {{- end }}
         {{- if .Values.cve.updater.nodeSelector }}
           nodeSelector:
 {{ toYaml .Values.cve.updater.nodeSelector | indent 12 }}

--- a/charts/core/templates/upgrader-cronjob.yaml
+++ b/charts/core/templates/upgrader-cronjob.yaml
@@ -48,6 +48,10 @@ spec:
           imagePullSecrets:
             - name: {{ .Values.imagePullSecrets }}
         {{- end }}
+        {{- if .Values.controller.certupgrader.tolerations }}
+          tolerations:
+{{ toYaml .Values.controller.certupgrader.tolerations | indent 12 }}
+        {{- end }}
         {{- if .Values.controller.certupgrader.nodeSelector }}
           nodeSelector:
 {{ toYaml .Values.controller.certupgrader.nodeSelector | indent 12 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -309,6 +309,7 @@ controller:
     priorityClassName:
     podLabels: {}
     podAnnotations: {}
+    tolerations: []
     nodeSelector:
       {}
       # key1: value1
@@ -557,6 +558,7 @@ cve:
       #   memory: 256Mi
     podLabels: {}
     podAnnotations: {}
+    tolerations: []
     nodeSelector:
       {}
       # key1: value1


### PR DESCRIPTION
Added missing tolerations config for cert-upgrader and cve-updater cronjobs, so its possible to install the core chart in a single node Kubernetes cluster.