### PR TITLE
feat: add support for probe config and ui svc labels

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -132,6 +132,10 @@ spec:
           {{- else }}
 {{ toYaml .Values.resources | indent 12 }}
           {{- end }}
+          {{- if .Values.controller.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.controller.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             exec:
               command:
@@ -139,6 +143,11 @@ spec:
                 - /tmp/ready
             initialDelaySeconds: 5
             periodSeconds: 5
+          {{- end }}
+          {{- if .Values.controller.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.controller.livenessProbe | nindent 12 }}
+          {{- end }}
           env:
             - name: CLUSTER_JOIN_ADDR
               value: neuvector-svc-controller.{{ .Release.Namespace }}

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -98,6 +98,14 @@ spec:
           {{- else }}
 {{ toYaml .Values.resources | indent 12 }}
           {{- end }}
+          {{- if .Values.enforcer.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.enforcer.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.enforcer.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.enforcer.livenessProbe | nindent 12 }}
+          {{- end }}
           env:
             - name: CLUSTER_JOIN_ADDR
               value: neuvector-svc-controller.{{ .Release.Namespace }}

--- a/charts/core/templates/manager-service.yaml
+++ b/charts/core/templates/manager-service.yaml
@@ -11,6 +11,9 @@ metadata:
   labels:
     chart: {{ template "neuvector.chart" . }}
     release: {{ .Release.Name }}
+    {{- with .Values.manager.svc.labels }}
+    {{- toYaml . | indent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.manager.svc.type }}
 {{- if and .Values.manager.svc.loadBalancerIP (eq .Values.manager.svc.type "LoadBalancer") }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -110,6 +110,10 @@ controller:
     {}
     # key1: value1
     # key2: value2
+  readinessProbe:
+    {}
+  livenessProbe:
+    {}
   apisvc:
     type:
     annotations: {}
@@ -348,6 +352,10 @@ enforcer:
     # requests:
     #   cpu: 100m
     #   memory: 2280Mi
+  readinessProbe:
+    {}
+  livenessProbe:
+    {}
   internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
     certificate:
       secret: "" 
@@ -379,6 +387,8 @@ manager:
       # azure
       # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
       # service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "apps-subnet"
+    labels:
+      {}
   # OpenShift Route configuration
   # Make sure manager env ssl is false for edge termination
   route:


### PR DESCRIPTION
Resolves https://github.com/neuvector/neuvector-helm/issues/252 by providing a way to configure probes across the controllers/enforcers.

Also adds support for labels on the manager service which is useful for Istio ambient waypoint usage (see [here](https://istio.io/latest/docs/ambient/usage/waypoint/#configure-a-service-to-use-a-specific-waypoint)).