### PR TITLE
feat: add TLS configuration support for ServiceMonitor

### DIFF
--- a/charts/monitor/templates/exporter-servicemonitor.yaml
+++ b/charts/monitor/templates/exporter-servicemonitor.yaml
@@ -36,4 +36,9 @@ spec:
       relabelings:
         {{- toYaml .Values.exporter.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
+      {{ if .Values.exporter.serviceMonitor.tlsConfig -}}
+      scheme: https
+      tlsConfig:
+        {{- toYaml .Values.exporter.serviceMonitor.tlsConfig | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -49,8 +49,15 @@ exporter:
     # Scrape interval. If not set, the Prometheus default scrape interval is used.
     interval: ""
     # MetricRelabelConfigs to apply to samples after scraping, but before ingestion.
-    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
     metricRelabelings: []
     # RelabelConfigs to apply to samples before scraping
-    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#relabelconfig
+    # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#relabelconfig
     relabelings: []
+    # tlsConfig to allow for TLS configuration of ServiceMonitor
+    # tlsConfig:
+    #  caFile:   /etc/prom-certs/root-cert.pem
+    #  certFile: /etc/prom-certs/cert-chain.pem
+    #  keyFile:  /etc/prom-certs/key.pem
+    #  insecureSkipVerify: true
+    tlsConfig: {}


### PR DESCRIPTION
Add tls configuration support to servicemonitors

This is required for servicemonitors to work in Istio. 

Signed-off-by: Dax McDonald <31839142+daxmc99@users.noreply.github.com>
