### PR TITLE
feat: support affinity in the enforcer daemonset

### DIFF
--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -55,6 +55,10 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets }}
     {{- end }}
+    {{- if .Values.enforcer.affinity }}
+      affinity:
+{{ toYaml .Values.enforcer.affinity | indent 8 }}
+    {{- end }}
     {{- if .Values.enforcer.tolerations }}
       tolerations:
 {{ toYaml .Values.enforcer.tolerations | indent 8 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -335,6 +335,7 @@ enforcer:
   podLabels: {}
   podAnnotations: {}
   env: []
+  affinity: {}
   tolerations:
     - effect: NoSchedule
       key: node-role.kubernetes.io/master


### PR DESCRIPTION
Using affinity in the Daemonset is useful to dodge Fargate nodes for example (single-pod nodes).

There might be other use cases too (Windows nodes maybe?).