### PR TITLE
NSVHAS-9776 Enforcer Daemonset missing etcd toleration

### DIFF
--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -340,6 +340,8 @@ enforcer:
       key: node-role.kubernetes.io/master
     - effect: NoSchedule
       key: node-role.kubernetes.io/control-plane
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/etcd
   resources:
     {}
     # limits:


### PR DESCRIPTION
Added below tolerations for the Enforcer daemon set,
```
- effect: NoSchedule
      key: node-role.kubernetes.io/etcd
```