### PR TITLE
NVSHAS-9996 NeuVector Helm chart should allow non-privileged mode of enforcer pods

### DIFF
--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -91,7 +91,11 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.enforcer.image.imagePullPolicy }}
           securityContext:
+          {{- if .Values.enforcer.securityContext }}
+{{ toYaml .Values.enforcer.securityContext | indent 12 }}
+          {{- else }}  
             privileged: true
+          {{- end }}
           resources:
           {{- if .Values.enforcer.resources }}
 {{ toYaml .Values.enforcer.resources | indent 12 }}

--- a/charts/core/templates/enforcer-daemonset.yaml
+++ b/charts/core/templates/enforcer-daemonset.yaml
@@ -91,11 +91,7 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.enforcer.image.imagePullPolicy }}
           securityContext:
-          {{- if .Values.enforcer.securityContext }}
 {{ toYaml .Values.enforcer.securityContext | indent 12 }}
-          {{- else }}  
-            privileged: true
-          {{- end }}
           resources:
           {{- if .Values.enforcer.resources }}
 {{ toYaml .Values.enforcer.resources | indent 12 }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -356,7 +356,7 @@ enforcer:
       keyFile: tls.key
       pemFile: tls.crt
       caFile: ca.crt # must be the same CA for all internal.
-
+  securityContext: {}
 manager:
   # If false, manager will not be installed
   enabled: true

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -356,7 +356,8 @@ enforcer:
       keyFile: tls.key
       pemFile: tls.crt
       caFile: ca.crt # must be the same CA for all internal.
-  securityContext: {}
+  securityContext:
+    privileged: true
 manager:
   # If false, manager will not be installed
   enabled: true


### PR DESCRIPTION
Now the users can add the non-privileged mode configurations using values.yaml file as shown below, if not the securityContext is set as "privileged" by default

```
enforcer:
  # If false, enforcer will not be installed
  enabled: true
  image:
    repository: neuvector/enforcer
    imagePullPolicy: IfNotPresent
    hash:
  updateStrategy:
    type: RollingUpdate
  priorityClassName:
  podLabels: {}
  podAnnotations:
       container.apparmor.security.beta.kubernetes.io/neuvector-enforcer-pod: unconfined
  env: []
  tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/master
    - effect: NoSchedule
      key: node-role.kubernetes.io/control-plane
    - effect: NoSchedule
      key: node-role.kubernetes.io/etcd
  resources:
    {}
  internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
    certificate:
      secret: ""
      keyFile: tls.key
      pemFile: tls.crt
      caFile: ca.crt # must be the same CA for all internal.
  securityContext:
    seccompProfile:
      type: Unconfined
    capabilities:
      add:
      - SYS_ADMIN
      - NET_ADMIN
      - SYS_PTRACE
      - IPC_LOCK

```

After deploying using HELM, below is the daemonset YAML configuration seen on the enforcer.

```
neuvector@K8-Master:~/helm/neuvector-helm-vj/charts/core$ kubectl get ds neuvector-enforcer-pod -o yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  annotations:
    deprecated.daemonset.template.generation: "1"
    meta.helm.sh/release-name: neuvector
    meta.helm.sh/release-namespace: neuvector
  creationTimestamp: "2025-06-25T18:02:27Z"
  generation: 1
  labels:
    app.kubernetes.io/managed-by: Helm
    chart: core-2.8.6
    release: neuvector
  name: neuvector-enforcer-pod
  namespace: neuvector
  resourceVersion: "31174984"
  uid: c43af93d-e3dd-43d3-a6f9-c67728805dd1
spec:
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: neuvector-enforcer-pod
  template:
    metadata:
      annotations:
        container.apparmor.security.beta.kubernetes.io/neuvector-enforcer-pod: unconfined
      creationTimestamp: null
      labels:
        app: neuvector-enforcer-pod
        release: neuvector
    spec:
      containers:
      - env:
        - name: CLUSTER_JOIN_ADDR
          value: neuvector-svc-controller.neuvector
        - name: CLUSTER_ADVERTISED_ADDR
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: CLUSTER_BIND_ADDR
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: status.podIP
        - name: AUTO_INTERNAL_CERT
          value: "1"
        image: docker.io/neuvector/enforcer:5.4.4
        imagePullPolicy: IfNotPresent
        name: neuvector-enforcer-pod
        resources: {}
        securityContext:
          capabilities:
            add:
            - SYS_ADMIN
            - NET_ADMIN
            - SYS_PTRACE
            - IPC_LOCK
          seccompProfile:
            type: Unconfined
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /lib/modules
          name: modules-vol
          readOnly: true
        - mountPath: /var/nv_debug
          name: nv-debug
        - mountPath: /etc/neuvector/certs/internal/
          name: internal-cert-dir
      dnsPolicy: ClusterFirst
      hostPID: true
      imagePullSecrets:
      - name: regsecret
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: default
      serviceAccountName: default
      terminationGracePeriodSeconds: 1200
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      - effect: NoSchedule
        key: node-role.kubernetes.io/control-plane
      - effect: NoSchedule
        key: node-role.kubernetes.io/etcd
      volumes:
      - hostPath:
          path: /lib/modules
          type: ""
        name: modules-vol
      - hostPath:
          path: /var/nv_debug
          type: ""
        name: nv-debug
      - emptyDir:
          sizeLimit: 50Mi
        name: internal-cert-dir
  updateStrategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate
status:
  currentNumberScheduled: 3
  desiredNumberScheduled: 3
  numberAvailable: 3
  numberMisscheduled: 0
  numberReady: 3
  observedGeneration: 1
  updatedNumberScheduled: 3
neuvector@K8-Master:~/helm/neuvector-helm-vj/charts/core$
```

