### PR TITLE
NVSHAS-10047 Add RBAC & CRD schema to helm chart for supporting response rule

### DIFF
--- a/charts/core/templates/crd-role-least.yaml
+++ b/charts/core/templates/crd-role-least.yaml
@@ -345,6 +345,63 @@ userNames:
 
 ---
 
+# ClusterRole for NeuVector to manage response rules
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRole
+metadata:
+  name: neuvector-binding-nvresponserulesecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - neuvector.com
+  resources:
+  - nvresponserulesecurityrules
+  verbs:
+  - get
+  - list
+  - delete
+    
+---
+
+# ClusterRoleBinding for NeuVector to manage response rules
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: neuvector-binding-nvresponserulesecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- end }}
+  name: neuvector-binding-nvresponserulesecurityrules
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:controller
+{{- end }}
+
+---
+
 # ClusterRole for NeuVector to manage vulnerability CRD profiles
 {{- if $oc3 }}
 apiVersion: authorization.openshift.io/v1

--- a/charts/core/templates/crd-role.yaml
+++ b/charts/core/templates/crd-role.yaml
@@ -402,6 +402,63 @@ userNames:
 
 ---
 
+# ClusterRole for NeuVector to manage response rules
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRole
+metadata:
+  name: neuvector-binding-nvresponserulesecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - neuvector.com
+  resources:
+  - nvresponserulesecurityrules
+  verbs:
+  - get
+  - list
+  - delete
+    
+---
+
+# ClusterRoleBinding for NeuVector to manage response rules
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: neuvector-binding-nvresponserulesecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- end }}
+  name: neuvector-binding-nvresponserulesecurityrules
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount }}
+{{- end }}
+
+---
+
 # Clusterrolebinding for Neuvector to manage name referral for common groups
 {{- if $oc3 }}
 apiVersion: authorization.openshift.io/v1
@@ -430,5 +487,4 @@ subjects:
 userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount }}
 {{- end }}
-
 {{- end }}

--- a/charts/core/templates/crd.yaml
+++ b/charts/core/templates/crd.yaml
@@ -192,6 +192,55 @@ spec:
                     - Protect
                     type: string
                 type: object
+              response:
+                items:
+                  properties:
+                    policy_name:
+                      enum:
+                      - default
+                      type: string
+                    event:
+                      enum:
+                      - event
+                      - security-event
+                      - cve-report
+                      - compliance
+                      type: string
+                    comment:
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          type:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - type
+                        - value
+                        type: object
+                      type: array
+                    actions:
+                      items:
+                        enum:
+                        - quarantine
+                        - suppress-log
+                        - webhook
+                        type: string
+                      minItems: 1
+                      type: array
+                    webhooks:
+                      items:
+                        type: string
+                      type: array
+                    disable:
+                      type: boolean
+                  required:
+                  - policy_name
+                  - event
+                  - actions
+                  type: object
+                type: array
               target:
                 properties:
                   policymode:
@@ -477,6 +526,55 @@ spec:
                     - Protect
                     type: string
                 type: object
+              response:
+                items:
+                  properties:
+                    policy_name:
+                      enum:
+                      - default
+                      type: string
+                    event:
+                      enum:
+                      - event
+                      - security-event
+                      - cve-report
+                      - compliance
+                      type: string
+                    comment:
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          type:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - type
+                        - value
+                        type: object
+                      type: array
+                    actions:
+                      items:
+                        enum:
+                        - quarantine
+                        - suppress-log
+                        - webhook
+                        type: string
+                      minItems: 1
+                      type: array
+                    webhooks:
+                      items:
+                        type: string
+                      type: array
+                    disable:
+                      type: boolean
+                  required:
+                  - policy_name
+                  - event
+                  - actions
+                  type: object
+                type: array
               target:
                 properties:
                   policymode:
@@ -1042,6 +1140,89 @@ spec:
                 type: object
             required:
             - selector
+            type: object
+        type: object
+{{- end }}
+---
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
+kind: CustomResourceDefinition
+metadata:
+  name: nvresponserulesecurityrules.neuvector.com
+spec:
+  group: neuvector.com
+  names:
+    kind: NvResponseRuleSecurityRule
+    listKind: NvResponseRuleSecurityRuleList
+    plural: nvresponserulesecurityrules
+    singular: nvresponserulesecurityrule
+  scope: Cluster
+{{- if (semverCompare "<1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+  version: v1
+{{- end }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              rule:
+                properties:
+                  policy_name:
+                    enum:
+                    - default
+                    type: string
+                  event:
+                    enum:
+                    - event
+                    - security-event
+                    - cve-report
+                    - compliance
+                    - admission-control
+                    type: string
+                  comment:
+                    type: string
+                  conditions:
+                    items:
+                      properties:
+                        type:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    type: array
+                  actions:
+                    items:
+                      enum:
+                      - quarantine
+                      - suppress-log
+                      - webhook
+                      type: string
+                    minItems: 1
+                    type: array
+                  webhooks:
+                    items:
+                      type: string
+                    type: array
+                  disable:
+                    type: boolean
+                required:
+                - policy_name
+                - event
+                - actions
+                type: object
+            required:
+            - rule
             type: object
         type: object
 {{- end }}

--- a/charts/crd/templates/crd.yaml
+++ b/charts/crd/templates/crd.yaml
@@ -72,10 +72,10 @@ spec:
                           type: array
                         name:
                           type: string
-                        original_name:
-                          type: string
                         name_referral:
                           type: boolean
+                        original_name:
+                          type: string
                       required:
                       - name
                       type: object
@@ -192,6 +192,55 @@ spec:
                     - Protect
                     type: string
                 type: object
+              response:
+                items:
+                  properties:
+                    policy_name:
+                      enum:
+                      - default
+                      type: string
+                    event:
+                      enum:
+                      - event
+                      - security-event
+                      - cve-report
+                      - compliance
+                      type: string
+                    comment:
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          type:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - type
+                        - value
+                        type: object
+                      type: array
+                    actions:
+                      items:
+                        enum:
+                        - quarantine
+                        - suppress-log
+                        - webhook
+                        type: string
+                      minItems: 1
+                      type: array
+                    webhooks:
+                      items:
+                        type: string
+                      type: array
+                    disable:
+                      type: boolean
+                  required:
+                  - policy_name
+                  - event
+                  - actions
+                  type: object
+                type: array
               target:
                 properties:
                   policymode:
@@ -478,6 +527,55 @@ spec:
                     - Protect
                     type: string
                 type: object
+              response:
+                items:
+                  properties:
+                    policy_name:
+                      enum:
+                      - default
+                      type: string
+                    event:
+                      enum:
+                      - event
+                      - security-event
+                      - cve-report
+                      - compliance
+                      type: string
+                    comment:
+                      type: string
+                    conditions:
+                      items:
+                        properties:
+                          type:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - type
+                        - value
+                        type: object
+                      type: array
+                    actions:
+                      items:
+                        enum:
+                        - quarantine
+                        - suppress-log
+                        - webhook
+                        type: string
+                      minItems: 1
+                      type: array
+                    webhooks:
+                      items:
+                        type: string
+                      type: array
+                    disable:
+                      type: boolean
+                  required:
+                  - policy_name
+                  - event
+                  - actions
+                  type: object
+                type: array
               target:
                 properties:
                   policymode:
@@ -1001,6 +1099,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: nvgroupdefinitions.neuvector.com
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: neuvector.com
   names:
@@ -1048,6 +1150,93 @@ spec:
                 type: object
             required:
             - selector
+            type: object
+        type: object
+{{- end }}
+---
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
+kind: CustomResourceDefinition
+metadata:
+  name: nvresponserulesecurityrules.neuvector.com
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: neuvector.com
+  names:
+    kind: NvResponseRuleSecurityRule
+    listKind: NvResponseRuleSecurityRuleList
+    plural: nvresponserulesecurityrules
+    singular: nvresponserulesecurityrule
+  scope: Cluster
+{{- if (semverCompare "<1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+  version: v1
+{{- end }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              rule:
+                properties:
+                  policy_name:
+                    enum:
+                    - default
+                    type: string
+                  event:
+                    enum:
+                    - event
+                    - security-event
+                    - cve-report
+                    - compliance
+                    - admission-control
+                    type: string
+                  comment:
+                    type: string
+                  conditions:
+                    items:
+                      properties:
+                        type:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - type
+                      - value
+                      type: object
+                    type: array
+                  actions:
+                    items:
+                      enum:
+                      - quarantine
+                      - suppress-log
+                      - webhook
+                      type: string
+                    minItems: 1
+                    type: array
+                  webhooks:
+                    items:
+                      type: string
+                    type: array
+                  disable:
+                    type: boolean
+                required:
+                - policy_name
+                - event
+                - actions
+                type: object
+            required:
+            - rule
             type: object
         type: object
 {{- end }}

--- a/test/crd_test.go
+++ b/test/crd_test.go
@@ -17,7 +17,7 @@ func TestCRD(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/crd.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 8 {
+	if len(outs) != 9 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }
@@ -33,7 +33,7 @@ func TestCoreCRD(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/crd.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 8 {
+	if len(outs) != 9 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }


### PR DESCRIPTION
 ```
kubectl create clusterrole neuvector-binding-nvresponserulesecurityrules --verb=list,get,delete --resource=nvresponserulesecurityrules
kubectl create clusterrolebinding neuvector-binding-nvresponserulesecurityrules --clusterrole=neuvector-binding-nvresponserulesecurityrules --serviceaccount=neuvector:controller --serviceaccount=neuvector:default
```
A new CRD nvresponserulesecurityrules.neuvector.com is added.
Two existing CRDs are updated: nvsecurityrules.neuvector.com & nvclustersecurityrules.neuvector.com