### PR TITLE
NVSHAS-10081 Adding support for fed configurations

### DIFF
--- a/charts/core/templates/crd-role-least.yaml
+++ b/charts/core/templates/crd-role-least.yaml
@@ -488,4 +488,60 @@ userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:controller
 {{- end }}
 
+---
+
+# ClusterRole for NeuVector to manage fed configurations
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRole
+metadata:
+  name: neuvector-binding-nvconfigsecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - neuvector.com
+  resources:
+  - nvconfigsecurityrules
+  verbs:
+  - get
+  - list
+  - delete
+
+---
+
+# ClusterRoleBinding for NeuVector to manage fed configurations
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: neuvector-binding-nvconfigsecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- end }}
+  name: neuvector-binding-nvconfigsecurityrules
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:controller
+{{- end }}
 {{- end }}

--- a/charts/core/templates/crd-role.yaml
+++ b/charts/core/templates/crd-role.yaml
@@ -487,4 +487,61 @@ subjects:
 userNames:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount }}
 {{- end }}
+
+---
+
+# ClusterRole for NeuVector to manage fed configurations
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRole
+metadata:
+  name: neuvector-binding-nvconfigsecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - neuvector.com
+  resources:
+  - nvconfigsecurityrules
+  verbs:
+  - get
+  - list
+  - delete
+
+---
+
+# Clusterrolebinding for Neuvector to manage fed configurations
+{{- if $oc3 }}
+apiVersion: authorization.openshift.io/v1
+{{- else if (semverCompare ">=1.8-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: v1
+{{- end }}
+kind: ClusterRoleBinding
+metadata:
+  name: neuvector-binding-nvconfigsecurityrules
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+roleRef:
+{{- if not $oc3 }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+{{- end }}
+  name: neuvector-binding-nvconfigsecurityrules
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
+{{- if $oc3 }}
+userNames:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount }}
+{{- end }}
 {{- end }}

--- a/charts/core/templates/crd.yaml
+++ b/charts/core/templates/crd.yaml
@@ -1234,4 +1234,59 @@ spec:
             type: object
         type: object
 {{- end }}
+---
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
+kind: CustomResourceDefinition
+metadata:
+  name: nvconfigsecurityrules.neuvector.com
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  group: neuvector.com
+  names:
+    kind: NvConfigSecurityRule
+    listKind: NvConfigSecurityRuleList
+    plural: nvconfigsecurityrules
+    singular: nvsystemconfiguration
+  scope: Cluster
+{{- if (semverCompare "<1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+  version: v1
+{{- end }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              webhooks:
+                items:
+                  properties:
+                    enable:
+                      type: boolean
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    url:
+                      type: string
+                      format: uri
+                    use_proxy:
+                      type: boolean
+                  required:
+                  - name
+                  - url
+                  type: object
+                type: array
+            type: object
+        type: object
+{{- end }}
 {{- end }}

--- a/charts/crd/templates/crd.yaml
+++ b/charts/crd/templates/crd.yaml
@@ -1242,3 +1242,59 @@ spec:
             type: object
         type: object
 {{- end }}
+---
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
+apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
+kind: CustomResourceDefinition
+metadata:
+  name: nvconfigsecurityrules.neuvector.com
+  labels:
+    chart: {{ template "neuvector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: neuvector.com
+  names:
+    kind: NvConfigSecurityRule
+    listKind: NvConfigSecurityRuleList
+    plural: nvconfigsecurityrules
+    singular: nvsystemconfiguration
+  scope: Cluster
+{{- if (semverCompare "<1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+  version: v1
+{{- end }}
+  versions:
+  - name: v1
+    served: true
+    storage: true
+{{- if (semverCompare ">=1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              webhooks:
+                items:
+                  properties:
+                    enable:
+                      type: boolean
+                    name:
+                      type: string
+                    type:
+                      type: string
+                    url:
+                      type: string
+                      format: uri
+                    use_proxy:
+                      type: boolean
+                  required:
+                  - name
+                  - url
+                  type: object
+                type: array
+            type: object
+        type: object
+{{- end }}

--- a/test/crd_test.go
+++ b/test/crd_test.go
@@ -17,7 +17,7 @@ func TestCRD(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/crd.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 9 {
+	if len(outs) != 10 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }
@@ -33,7 +33,7 @@ func TestCoreCRD(t *testing.T) {
 	out := helm.RenderTemplate(t, options, helmChartPath, nvRel, []string{"templates/crd.yaml"})
 	outs := splitYaml(out)
 
-	if len(outs) != 9 {
+	if len(outs) != 10 {
 		t.Errorf("Resource count is wrong. count=%v\n", len(outs))
 	}
 }


### PR DESCRIPTION
Added HELM support for these commands,
```

kubectl create clusterrole neuvector-binding-nvconfigsecurityrules --verb=list,get,delete --resource=nvconfigsecurityrules
kubectl create clusterrolebinding neuvector-binding-nvconfigsecurityrules --clusterrole=neuvector-binding-nvconfigsecurityrules --serviceaccount=neuvector:controller --serviceaccount=neuvector:default

```
A new CRD nvconfigsecurityrules.neuvector.com is added.
