### PR TITLE
fix(cert-upgrader): remove hardcoded cert-upgrader-uid annotation to prevent Helm drift

### DIFF
--- a/charts/core/templates/upgrader-cronjob.yaml
+++ b/charts/core/templates/upgrader-cronjob.yaml
@@ -10,8 +10,10 @@ kind: CronJob
 metadata:
   name: neuvector-cert-upgrader-pod
   namespace: {{ .Release.Namespace }}
+{{- with .Values.controller.certupgrader.annotations }}
   annotations:
-    cert-upgrader-uid: ""
+{{ toYaml . | nindent 4 }}
+{{- end }}
   labels:
     chart: {{ template "neuvector.chart" . }}
     release: {{ .Release.Name }}
@@ -76,8 +78,8 @@ spec:
               image: {{ include "neuvector.controller.image" . | quote }}
               imagePullPolicy: {{ .Values.controller.certupgrader.imagePullPolicy }}
               resources:
-{{ toYaml .Values.controller.certupgrader.resources | indent 16 }}                
-              command: 
+{{ toYaml .Values.controller.certupgrader.resources | indent 16 }}
+              command:
                 - /usr/local/bin/upgrader
                 - upgrader-job
               {{- if and .Values.internal.autoRotateCert }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -64,7 +64,7 @@ autoGenerateCert: true
 
 defaultValidityPeriod: 365
 
-internal: 
+internal:
   certmanager: # enable when cert-manager is installed for the internal certificates
     enabled: false
     secretname: neuvector-internal
@@ -114,7 +114,7 @@ controller:
     ctrlServerPort: 10443
     type:
     annotations: {}
-    nodePort:  
+    nodePort:
     # OpenShift Route configuration
     # Controller supports HTTPS only, so edge termination not supported
     route:
@@ -306,8 +306,11 @@ controller:
     # default: "" (off)
     schedule: ""
     imagePullPolicy: IfNotPresent
-    timeout: 3600 
+    timeout: 3600
     priorityClassName:
+    annotations:
+      # cert-upgrader-uid: ""
+    tls: false
     resources:
       {}
       # limits:
@@ -361,7 +364,7 @@ enforcer:
     #   memory: 2280Mi
   internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
     certificate:
-      secret: "" 
+      secret: ""
       keyFile: tls.key
       pemFile: tls.crt
       caFile: ca.crt # must be the same CA for all internal.
@@ -385,7 +388,7 @@ manager:
   svc:
     mgrServerPort: 8443
     type: ClusterIP
-    nodePort:  
+    nodePort:
     loadBalancerIP:
     annotations:
       {}
@@ -545,7 +548,7 @@ cve:
       secretName: # my-tls-secret
     internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
       certificate:
-        secret: "" 
+        secret: ""
         keyFile: tls.key
         pemFile: tls.crt
         caFile: ca.crt # must be the same CA for all internal.
@@ -615,11 +618,11 @@ cve:
     runAsUser: # MUST be set for Rancher hardened cluster
     internal: # this is used for internal communication. Please use the SAME CA for all the components (controller, scanner, adapter and enforcer)
       certificate:
-        secret: "" 
+        secret: ""
         keyFile: tls.key
         pemFile: tls.crt
         caFile: ca.crt # must be the same CA for all internal.
-    volumes: 
+    volumes:
     volumeMounts:
 resources:
   {}


### PR DESCRIPTION
The cert-upgrader CronJob template previously hardcoded:

```
  annotations:
    cert-upgrader-uid: ""
```
The upgrader job mutates this annotation at runtime to store its execution UID. Because the chart rendered a static empty value, ArgoCD always detected drift after the first execution.

Closes https://github.com/neuvector/neuvector-helm/issues/544