### PR TITLE
fix: use httpGet for controller readniness probe

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -135,11 +135,10 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           {{- end }}
           readinessProbe:
-            exec:
-              command:
-                - cat
-                - /tmp/ready
-            initialDelaySeconds: 5
+            httpGet:
+              path: /ready
+              port: 18500
+            initialDelaySeconds: 10
             periodSeconds: 5
           env:
             - name: CTRL_SERVER_PORT


### PR DESCRIPTION
## Description

Use `httpGet` instead of `exec` in readiness probe.  

Fix [#2227](https://github.com/neuvector/neuvector/issues/2227)

More information why we need this can be found in this PR: https://github.com/neuvector/neuvector/pull/2383

## Test

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
