### PR TITLE
feat: bump versions using updatecli for v2.9

### DIFF
--- a/.github/workflows/update-charts.yml
+++ b/.github/workflows/update-charts.yml
@@ -1,0 +1,25 @@
+name: Update helm charts
+on:
+  workflow_dispatch:
+jobs:
+  update-helm-charts:
+    name: Update neuvector charts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for updatecli to update the repository
+      pull-requests: write # for updatecli to create a PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@e71be7554f3f940bc439cf720b3e4e379823c562 # v3.2.0
+
+      - name: Update neuvector charts
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+          UPDATECLI_GITHUB_BRANCH: ${{ github.ref_name }}
+        run: "updatecli compose apply --file updatecli/updatecli-compose.release.yaml"

--- a/updatecli/updatecli-compose.release.yaml
+++ b/updatecli/updatecli-compose.release.yaml
@@ -1,0 +1,6 @@
+policies:
+  - name: Update Helm Chart
+    config:
+      - "updatecli.release.d"
+    values:
+      - values.yaml

--- a/updatecli/updatecli.release.d/bump-helm-chart-version.yaml
+++ b/updatecli/updatecli.release.d/bump-helm-chart-version.yaml
@@ -1,0 +1,190 @@
+name: Update neuvector chart versions
+
+sources:
+  # core and crd share exactly the same version
+  chartVersion:
+    name: "Get latest neuvector helm version"
+    kind: yaml
+    transformers:
+      - semverinc: patch
+    spec:
+      file: charts/core/Chart.yaml
+      key: $.version
+  appVersion:
+    name: "Get latest neuvector version"
+    kind: githubrelease
+    transformers:
+      - trimPrefix: "v"
+    spec:
+      owner: '{{ requiredEnv .github.owner }}'
+      repository: neuvector
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "regex"
+        pattern: "^v5\\.4\\.\\d+$"
+  monitorVersion:
+    name: "Get latest prometheus-exporter version"
+    kind: githubrelease
+    transformers:
+      - trimPrefix: "v"
+    spec:
+      owner: '{{ requiredEnv .github.owner }}'
+      repository: prometheus-exporter
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "semver"
+  complianceVersion:
+    name: "Get latest compliance-config version"
+    kind: yaml
+    transformers:
+      - semverinc: patch
+    spec:
+      file: charts/core/values.yaml
+      key: $.controller.prime.image.tag
+  adapterVersion:
+    name: "Get latest adapter version"
+    kind: githubrelease
+    transformers:
+      - trimPrefix: "v"
+    spec:
+      owner: '{{ requiredEnv .github.owner }}'
+      repository: registry-adapter
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "semver"
+  updaterVersion:
+    name: "Get latest updater version"
+    kind: githubrelease
+    transformers:
+      - trimPrefix: "v"
+    spec:
+      owner: '{{ requiredEnv .github.owner }}'
+      repository: updater
+      token: '{{ requiredEnv .github.token }}'
+      versionfilter:
+        kind: "semver"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      directory: "/tmp/helm-charts"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "neuvector-helm"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ requiredEnv .github.branch }}"
+      commitusingapi: true
+      commitmessage:
+        type: "chore"
+        title: "update neuvector helm charts"
+        hidecredit: true
+        footers: "Signed-off-by: NeuVector bot <neuvector-bot@users.noreply.github.com>"
+
+actions:
+  default:
+    title: 'chore: helm chart {{ source "chartVersion" }} release'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Helm chart {{ source "chartVersion" }} update.
+        This PR has been created by the automation used to automatically update the Helm charts when neuvector is released or helm chart content is updated.
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
+      draft: false
+      labels:
+        - "chore"
+
+targets:
+  update_core_version:
+    scmid: default
+    name: update Helm chart version
+    kind: yaml
+    sourceid: chartVersion
+    spec:
+      file: charts/core/Chart.yaml
+      key: $.version
+  update_core_appversion:
+    scmid: default
+    name: update Helm chart appVersion
+    kind: yaml
+    sourceid: appVersion
+    spec:
+      file: charts/core/Chart.yaml
+      key: $.appVersion
+  update_nv_tag:
+    scmid: default
+    name: update NV tag
+    kind: yaml
+    sourceid: appVersion
+    spec:
+      file: charts/core/values.yaml
+      key: $.tag
+  update_compliance_config_tag:
+    scmid: default
+    name: update compliance tag
+    kind: yaml
+    sourceid: complianceVersion
+    spec:
+      file: charts/core/values.yaml
+      key: $.controller.prime.image.tag
+  update_adapter_tag:
+    scmid: default
+    name: update adapter tag
+    kind: yaml
+    sourceid: adapterVersion
+    spec:
+      file: charts/core/values.yaml
+      key: $.cve.adapter.image.tag
+  update_updater_tag:
+    scmid: default
+    name: update updater tag
+    kind: yaml
+    sourceid: updaterVersion
+    spec:
+      file: charts/core/values.yaml
+      key: $.cve.updater.image.tag
+  update_crd_version:
+    scmid: default
+    name: update Helm chart version
+    kind: yaml
+    sourceid: chartVersion
+    spec:
+      file: charts/crd/Chart.yaml
+      key: $.version
+  update_crd_appversion:
+    scmid: default
+    name: update Helm chart appVersion
+    kind: yaml
+    sourceid: appVersion
+    spec:
+      file: charts/crd/Chart.yaml
+      key: $.appVersion
+  update_monitor_version:
+    scmid: default
+    name: update Helm chart version
+    kind: yaml
+    sourceid: chartVersion
+    spec:
+      file: charts/monitor/Chart.yaml
+      key: $.version
+  update_monitor_appversion:
+    scmid: default
+    name: update Helm chart appVersion
+    kind: yaml
+    sourceid: monitorVersion
+    spec:
+      file: charts/monitor/Chart.yaml
+      key: $.appVersion
+  update_monitor_tag:
+    scmid: default
+    name: update prometheus exporter tag
+    kind: yaml
+    sourceid: monitorVersion
+    spec:
+      file: charts/monitor/values.yaml
+      key: $.exporter.image.tag

--- a/updatecli/updatecli.release.d/bump-helm-chart-version.yaml
+++ b/updatecli/updatecli.release.d/bump-helm-chart-version.yaml
@@ -33,6 +33,7 @@ sources:
       token: '{{ requiredEnv .github.token }}'
       versionfilter:
         kind: "semver"
+        pattern: "~1.0"
   complianceVersion:
     name: "Get latest compliance-config version"
     kind: yaml

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,7 @@
+github:
+  owner: "UPDATECLI_GITHUB_OWNER"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "UPDATECLI_GITHUB_BRANCH"
+  author: "NeuVector bot"
+  user: "UPDATECLI_GITHUB_OWNER"
+  email: "neuvector-bot@users.noreply.github.com"


### PR DESCRIPTION
## Description

This PR introduces updatecli to update chart version, appVersion, and related tags. It does the following things:

1. Increment the existing chart version.
2. Update appVersion based on the NV release.  (5.4 for v2.9, 5.5 for v2.10 and 5.6 for master branch)
3. Update updater, prometheus-exporter, register-adapter tags based on their latest release.
4. Increment version of compliance-config.

To trigger this, run the workflow based on the branch you want to bump.

## Test

These PRs are created in my fork based on the tags I have:

master: https://github.com/holyspectral/neuvector-helm/pull/16
2.10: https://github.com/holyspectral/neuvector-helm/pull/15
2.9: https://github.com/holyspectral/neuvector-helm/pull/14

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
