### PR TITLE
chore: support renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,34 @@
+{
+  "extends": [
+    "github>rancher/renovate-config#release"
+  ],
+  "baseBranchPatterns": [
+    "master",
+    "release/v2.10",
+    "release/v2.9"
+  ],
+  "prHourlyLimit": 4,
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths",
+    "gomodVendor"
+  ],
+  "ignorePaths": [
+    "test/vendor/**/Dockerfile",
+    "test/vendor/**/requirements.txt"
+  ],
+  "packageRules": [
+    {
+      "description": "Enable security only bumps for release branches",
+      "enabled": false,
+      "matchBaseBranches": [
+        "release/v2.10",
+        "release/v2.9"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
+}

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -1,0 +1,29 @@
+name: Renovate
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: "info"
+        type: string
+      overrideSchedule:
+        description: "Override all schedules"
+        required: false
+        default: "false"
+        type: string
+  # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
+  schedule:
+    - cron: '30 4,6 * * 1-5'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  call-workflow:
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@747810163961a087a611b3e5518413bb891c97f0 # release
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}
+      overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
+    secrets: inherit


### PR DESCRIPTION
## Description

Support renovate to update dependencies.  
- master: all possible dependencies.
- release/v2.10 and release/v2.9: only security patches. 

## Test

This would require a few rounds of testing in master branch.

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
