### PR TITLE
fix: use httpGet for controller readniness probe (2.10)

### DIFF
--- a/charts/core/templates/controller-deployment.yaml
+++ b/charts/core/templates/controller-deployment.yaml
@@ -135,11 +135,10 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           {{- end }}
           readinessProbe:
-            exec:
-              command:
-                - cat
-                - /tmp/ready
-            initialDelaySeconds: 5
+            httpGet:
+              path: /ready
+              port: 18500
+            initialDelaySeconds: 10
             periodSeconds: 5
           env:
             - name: CTRL_SERVER_PORT


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #XXX

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
