### PR TITLE
chore(renovate): update renovate.json to include release/v2.11 branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   ],
   "baseBranchPatterns": [
     "master",
+    "release/v2.11",
     "release/v2.10",
     "release/v2.9"
   ],
@@ -22,6 +23,7 @@
       "description": "Enable security only bumps for release branches",
       "enabled": false,
       "matchBaseBranches": [
+        "release/v2.11",
         "release/v2.10",
         "release/v2.9"
       ]


### PR DESCRIPTION
## Description

Update renovate.json to include release/v2.11 branch (which is for NV 5.6.x)

## Test

## Additional Information

### Tradeoff

### Potential improvement

