### PR TITLE
fix: remove the typo ctrlSercretName

### DIFF
--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -16,7 +16,6 @@ exporter:
   # changes this to a readonly user !
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin
-  ctrlSercretName: ''
   enforcerStats:
     enabled: false
   ctrlSecretName: ''


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix #574

There was a duplicate value for ctrlSecretName. The value was also a typo. 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

I can see this [PR](https://github.com/neuvector/neuvector-helm/blob/92bbb311e24a202bd79cfd0fdf7e78b62f024b71/charts/monitor/values.yaml)  introduces this duplicate value. 