### PR TITLE
chore: bump helm chart versions for NeuVector 5.6.1

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -1,7 +1,7 @@
 name: core
 apiVersion: v1
-version: 2.11.0
-appVersion: 5.6.0
+version: 2.11.1
+appVersion: 5.6.1
 description: Helm chart for NeuVector's core services
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -5,7 +5,7 @@
 openshift: false
 
 registry: docker.io
-tag: 5.6.0
+tag: 5.6.1
 oem:
 imagePullSecrets:
 psp: false
@@ -330,7 +330,7 @@ controller:
     image:
       repository: neuvector/compliance-config
       imagePullPolicy: IfNotPresent
-      tag: 1.0.15
+      tag: 1.0.16
       hash:
 enforcer:
   # If false, enforcer will not be installed
@@ -467,7 +467,7 @@ cve:
     image:
       repository: neuvector/registry-adapter
       imagePullPolicy: IfNotPresent
-      tag: 0.2.9
+      tag: 0.2.10
       hash:
     priorityClassName:
     resources:
@@ -559,7 +559,7 @@ cve:
       registry: ""
       repository: neuvector/updater
       imagePullPolicy: IfNotPresent
-      tag: 0.0.13
+      tag: 0.0.14
       hash:
     schedule: "0 0 * * *"
     priorityClassName:

--- a/charts/crd/Chart.yaml
+++ b/charts/crd/Chart.yaml
@@ -1,7 +1,7 @@
 name: crd
 apiVersion: v1
-version: 2.11.0
-appVersion: 5.6.0
+version: 2.11.1
+appVersion: 5.6.1
 description: Helm chart for NeuVector's CRD services
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4

--- a/charts/monitor/Chart.yaml
+++ b/charts/monitor/Chart.yaml
@@ -1,7 +1,7 @@
 name: monitor
 apiVersion: v1
-version: 2.11.0
-appVersion: 1.0.16
+version: 2.11.1
+appVersion: 1.0.18
 description: Helm chart for NeuVector monitor services
 home: https://neuvector.com
 icon: https://avatars2.githubusercontent.com/u/19367275?s=200&v=4

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -12,7 +12,7 @@ exporter:
   image:
     repository: neuvector/prometheus-exporter
     imagePullPolicy: IfNotPresent
-    tag: 1.0.16
+    tag: 1.0.18
   # changes this to a readonly user !
   CTRL_USERNAME: admin
   CTRL_PASSWORD: admin


### PR DESCRIPTION
## Description

bump chart version to 2.11.1 for NV 5.6.1

## Test

## Additional Information

### Tradeoff

