### PR TITLE
controller: publish not-ready addresses on the headless service

### DIFF
--- a/charts/core/templates/controller-service.yaml
+++ b/charts/core/templates/controller-service.yaml
@@ -9,6 +9,7 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - port: 18300
       protocol: "TCP"


### PR DESCRIPTION
The controller resolves `neuvector-svc-controller` to find peers to join. That Service is headless and doesn't set `publishNotReadyAddresses`, so it only lists ready endpoints, and controller readiness is gated on having joined the cluster. With a single replica there's no peer to bootstrap against, so if the first resolve fails the controller can't recover: it isn't ready, so it isn't in the endpoint list, so there's nothing left to resolve.

We hit this on a 2-node k3s cluster when both nodes rebooted and the CNI hadn't finished programming the datapath:

```
orchestration.GetK8sVersion: Get Version fail - error=Get "https://kubernetes.default/version":
  dial tcp: lookup kubernetes.default on 10.43.0.10:53: connect: no route to host
...
cluster.FillClusterAddrs: resolve - join=neuvector-svc-controller.neuvector retry=1
```

DNS recovered a few seconds later, but the controller stayed in that loop for 2 days 7 hours and reached retry 6470. For the whole period every neuvector Service had zero endpoints. The enforcers kept enforcing their last known policy but the cluster reported nothing, and the prometheus exporter crashlooped 631 times against a controller it couldn't reach. Deleting the controller pod cleared it straight away: with DNS working the first resolve returns empty, it elects itself, and it's ready in 26 seconds.

That asymmetry is the problem. Whether the cluster ever comes up depends on whether DNS happens to answer during the first few seconds of controller startup, and a single replica has nothing to fall back on. `publishNotReadyAddresses` is the field Kubernetes provides for exactly this kind of peer discovery during bootstrap.

Once a cluster is up this changes nothing, since ready endpoints are published either way.

Tested on six k3s clusters running 5.6.0 with chart 2.11.0, both single-replica and 3-replica controllers.
